### PR TITLE
Audit follow-up: bug fixes, refactors, tests and full docs revamp

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.5'
           tools: composer
           coverage: none
 
@@ -31,8 +31,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.composercache.outputs.dir }}
-          key: ${{ runner.os }}-php8.2-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-php8.2-composer-
+          key: ${{ runner.os }}-php8.5-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-php8.5-composer-
 
       - name: Install dependencies
         run: composer update --no-interaction --prefer-dist --ansi

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.5'
           tools: composer
           coverage: none
 
@@ -31,8 +31,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.composercache.outputs.dir }}
-          key: ${{ runner.os }}-php8.2-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-php8.2-composer-
+          key: ${{ runner.os }}-php8.5-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-php8.5-composer-
 
       - name: Install dependencies
         run: composer update --no-interaction --prefer-dist --ansi

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.3', '8.4']
+        php-versions: ['8.2', '8.3', '8.4', '8.5']
         mysql-versions: ['8.0', '8.4']
 
     services:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.3', '8.4', '8.5']
+        php-versions: ['8.2', '8.3', '8.4']
         mysql-versions: ['8.0', '8.4']
 
     services:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -81,7 +81,7 @@ jobs:
         run: composer test -- --color=always --coverage-clover=build/logs/clover.xml
 
       - name: Upload coverage to Coveralls
-        if: matrix.php-versions == '8.2' && matrix.mysql-versions == '8.0'
+        if: matrix.php-versions == '8.5' && matrix.mysql-versions == '8.0'
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -101,4 +101,4 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
-          carryforward: "PHP-8.2-MySQL-8.0"
+          carryforward: "PHP-8.5-MySQL-8.0"

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.5'
           tools: composer
           coverage: none
 
@@ -31,8 +31,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.composercache.outputs.dir }}
-          key: ${{ runner.os }}-php8.2-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-php8.2-composer-
+          key: ${{ runner.os }}-php8.5-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-php8.5-composer-
 
       - name: Install dependencies
         run: composer update --no-interaction --prefer-dist --ansi

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.5'
           tools: composer
           coverage: none
 
@@ -31,8 +31,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.composercache.outputs.dir }}
-          key: ${{ runner.os }}-php8.2-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-php8.2-composer-
+          key: ${{ runner.os }}-php8.5-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-php8.5-composer-
 
       - name: Install dependencies
         run: composer update --no-interaction --prefer-dist --ansi

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -8,6 +8,7 @@ $finder = Finder::create()
     ->files()
     ->in([
         __DIR__ . '/src/',
+        __DIR__ . '/tests/',
     ])
     ->exclude('build')
     ->append([

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,13 +33,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `Daycry\Doctrine\DataTables\Builder::parseFilterOperator()` regex now matches
   only documented operators (`!=, ><, >, <, =, %%, %, IN, OR, LIKE`); accidental
-  `•` (U+2022) matches are no longer accepted.
+  `•` (U+2022) matches are no longer accepted. Unknown bracket prefixes
+  (e.g. `[XYZ]term`) still fall back to `LIKE '%term%'` — the prefix is
+  stripped before the LIKE is applied, preserving the legacy typo-tolerant
+  behaviour.
 - `Daycry\Doctrine\DataTables\Builder` — operator `[><]` now throws
   `InvalidArgumentException` if the value count is not exactly 2 (it previously
   failed silently).
 - `Daycry\Doctrine\DataTables\Builder` — DataTables `search.regex: true` and
-  per-column `regex: true` now raise `InvalidArgumentException` (they were
-  silently ignored before). Use bracket-prefix operators instead.
+  per-column `regex: true` raise `InvalidArgumentException` **only when the
+  matching search value is non-empty**. The flag is tolerated alongside an
+  empty value so existing payloads that include `regex` for every column
+  keep working. Use bracket-prefix operators for any actual filtering.
 - `Daycry\Doctrine\Debug\Filters\DoctrineSlcReset::before()` now actually
   resets SLC statistics by calling
   `Services::doctrine()->resetSecondLevelCacheStatistics()`. Previously it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,86 @@
+# Changelog
+
+All notable changes to `daycry/doctrine` are documented in this file.
+
+The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- `Daycry\Doctrine\Helpers\getFromCacheOrQuery()` cache-aside helper, autoloaded
+  as a global function via `composer.json` `autoload.files`. Backed by the
+  configured Doctrine `resultsCache` PSR-6 pool. Accepts an optional `$dbGroup`
+  for multi-database setups.
+- `Daycry\Doctrine\Doctrine::getEm()` returns the underlying `EntityManager`
+  and throws `RuntimeException` if it has not been initialised.
+- `Daycry\Doctrine\DataTables\Builder::withMaxFilterValues(int)` to cap
+  `[IN]` and `[OR]` value lists. Default `500`; throws on `< 1`. Use
+  `PHP_INT_MAX` to disable.
+- `Daycry\Doctrine\Debug\Toolbar\Collectors\DoctrineCollector::setMaxQueries(int)`
+  with FIFO discard. Default `1000`; `0` disables the cap.
+- `Daycry\Doctrine\Libraries\InitializesNativeClient` trait shared between
+  the `Memcached` and `Redis` cache wrappers.
+- `tests/ServicesTest.php` — covers `Services::doctrine()` shared/unshared and
+  `Services::resetDoctrine()`.
+- `tests/GetFromCacheOrQueryTest.php` — covers cache hit, cache miss, TTL = 0,
+  and "result cache disabled" code paths.
+- `CHANGELOG.md` (this file).
+- Documentation revamp: `Requirements` and `Features` sections, multi-DB usage,
+  `getEm()` / `reOpen()` examples, SLC stats reset filter, canonical operator
+  reference in `docs/search_modes.md`.
+
+### Changed
+- `Daycry\Doctrine\DataTables\Builder::parseFilterOperator()` regex now matches
+  only documented operators (`!=, ><, >, <, =, %%, %, IN, OR, LIKE`); accidental
+  `•` (U+2022) matches are no longer accepted.
+- `Daycry\Doctrine\DataTables\Builder` — operator `[><]` now throws
+  `InvalidArgumentException` if the value count is not exactly 2 (it previously
+  failed silently).
+- `Daycry\Doctrine\DataTables\Builder` — DataTables `search.regex: true` and
+  per-column `regex: true` now raise `InvalidArgumentException` (they were
+  silently ignored before). Use bracket-prefix operators instead.
+- `Daycry\Doctrine\Debug\Filters\DoctrineSlcReset::before()` now actually
+  resets SLC statistics by calling
+  `Services::doctrine()->resetSecondLevelCacheStatistics()`. Previously it
+  was a no-op despite being documented as functional.
+- `Daycry\Doctrine\Debug\Toolbar\Collectors\DoctrineCollector` memoises both
+  the SLC logger lookup and the `getData()` payload, removing duplicate
+  service look-ups during a single toolbar render.
+- `Daycry\Doctrine\Commands\DoctrinePublish` now exits with status `1` on
+  error paths (read failure, missing autoload, prompted cancellation).
+- `Daycry\Doctrine\Libraries\Memcached::getInstance()` and
+  `Daycry\Doctrine\Libraries\Redis::getInstance()` now return precise types
+  (`?\Memcached`, `?\Redis`) instead of `mixed`.
+- `rector.php` now targets PHP 8.2 (was 7.4); applies `match` expressions,
+  constructor promotion and other 8.x refactors via `LevelSetList::UP_TO_PHP_82`.
+- `phpunit.xml.dist` no longer excludes `src/Config/`, `src/Commands/`,
+  `src/Cache/` from coverage; only `src/cli-config.php` remains excluded.
+- `.php-cs-fixer.dist.php` now also formats `tests/`.
+- `tests/_support/Database/Seeds/TestSeeder.php` is idempotent
+  (`truncate()` → `insertBatch()`).
+
+### Removed
+- Documented operator `[*%]` (it was never implemented in the code; with the
+  current regex it silently fell back to `[%]`).
+- PHP 8.5 from the `phpunit.yml` matrix until the language reaches GA.
+- `Daycry\Doctrine\Doctrine::convertDbConfigPdo()` — no callers, dead code.
+- `Daycry\Doctrine\Debug\Toolbar\Collectors\DoctrineCollector::debugToolbarDisplayPublic()`
+  — test-only escape hatch; tests now exercise the highlighter via
+  `display()`.
+- Broken doc links to `docs/DATATABLES_FIX.md` and `docs/TEST_COVERAGE.md`.
+
+### Fixed
+- The documented helper `getFromCacheOrQuery()` now actually exists.
+- The documented `DoctrineSlcReset` filter now performs its job.
+- Doc-code mismatch around the `[*%]` operator in `README.md`.
+
+### Documentation
+- Canonical operator reference now lives in
+  [`docs/search_modes.md`](docs/search_modes.md). `README.md` and
+  `docs/datatables.md` link to it instead of duplicating the table.
+- New "Multi-Database Groups" section in [`docs/usage.md`](docs/usage.md).
+- New "Memory Management" and "Resetting Stats per Request" sections in
+  [`docs/debug_toolbar.md`](docs/debug_toolbar.md).
+- `customTypeMappings`, `proxyFactory` and `secondLevelCacheTtl` documented
+  in detail in [`docs/configuration.md`](docs/configuration.md).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Doctrine
 
-Doctrine for Codeigniter 4
+Doctrine ORM 3 integration for CodeIgniter 4.
 
 [![PHPUnit](https://github.com/daycry/doctrine/actions/workflows/phpunit.yml/badge.svg?branch=master)](https://github.com/daycry/doctrine/actions/workflows/phpunit.yml)
 [![PHPStan](https://github.com/daycry/doctrine/actions/workflows/phpstan.yml/badge.svg?branch=master)](https://github.com/daycry/doctrine/actions/workflows/phpstan.yml)
@@ -15,292 +15,233 @@ Doctrine for Codeigniter 4
 [![GitHub stars](https://img.shields.io/github/stars/daycry/doctrine)](https://packagist.org/packages/daycry/doctrine)
 [![GitHub license](https://img.shields.io/github/license/daycry/doctrine)](https://github.com/daycry/doctrine/blob/master/LICENSE)
 
+## Features
+
+- ORM integration via `\Daycry\Doctrine\Doctrine` and `\Config\Services::doctrine()`.
+- Server-side **DataTables Builder** with safe operator parsing, whitelisted columns, and `[><]` / `[IN]` / `[OR]` validation.
+- **CodeIgniter Debug Toolbar** collector with optional Second-Level Cache (SLC) statistics badge.
+- **Doctrine Second-Level Cache** wired to the framework cache backend (file, Redis, Memcached, array).
+- `getFromCacheOrQuery()` cache-aside helper backed by the configured PSR-6 result cache.
+- **Multi-database group support** — get a separate Doctrine instance per `Config\Database` group.
+
+## Requirements
+
+- PHP **≥ 8.2**
+- CodeIgniter **^4**
+- Doctrine ORM **^3**, DBAL **^4**
+- Symfony Cache **^7**
+
+See [`composer.json`](composer.json) for the complete dependency graph.
+
 ## Documentation Index
 
 - [Installation](docs/installation.md)
 - [Configuration](docs/configuration.md)
-- [Usage](docs/usage.md)
+- [Usage](docs/usage.md) — service, helper, multi-DB, `getFromCacheOrQuery`, advanced API
 - [CLI Commands](docs/cli_commands.md)
-- [Using DataTables](docs/datatables.md)
-    - Filtering operators and search behavior documented in `docs/datatables.md`.
-- [DataTables Search Modes](docs/search_modes.md)
-- [Viewing Doctrine Queries in the Debug Toolbar](docs/debug_toolbar.md)
-- [Second-Level Cache (SLC)](docs/second_level_cache.md) — Enable Doctrine entity caching across requests. SLC uses the same cache backend configured in CodeIgniter (`Config\Cache`) and its `ttl`; toggle on/off in `Config\Doctrine`.
- - [SLC Statistics](docs/second_level_cache_stats.md) — How to enable hits/misses/puts counters and view them in the Debug Toolbar.
+- [DataTables Builder](docs/datatables.md)
+- [DataTables Search Modes](docs/search_modes.md) — canonical operator reference
+- [Debug Toolbar](docs/debug_toolbar.md) — query log + SLC stats + per-request reset filter
+- [Second-Level Cache (SLC)](docs/second_level_cache.md)
+- [SLC Statistics](docs/second_level_cache_stats.md)
+- [Changelog](CHANGELOG.md)
 
-## Installation via composer
+## Installation
 
-Use the package with composer install
-
-	> composer require daycry/doctrine
-
-## Configuration
-
-Run command:
-
-	> php spark doctrine:publish
-
-This command will copy a config file to your app namespace and "cli-config.php" file for doctrine cli.
-Then you can adjust it to your needs. By default file will be present in `app/Config/Doctrine.php`.
-
-
-## Usage Loading Library
-
-```php
-$doctrine = new \Daycry\Doctrine\Doctrine();
-$data = $doctrine->em->getRepository( 'App\Models\Entity\Class' )->findOneBy( array( 'id' => 1 ) );
-var_dump( $data );
-
+```bash
+composer require daycry/doctrine
 ```
 
-## Usage as a Service
+Then publish the configuration:
+
+```bash
+php spark doctrine:publish
+```
+
+This copies `Config/Doctrine.php` into your app namespace and `cli-config.php`
+into the project root for use with the Doctrine ORM CLI.
+
+## Quick Start
+
+### As a service
 
 ```php
 $doctrine = \Config\Services::doctrine();
-$data = $doctrine->em->getRepository( 'App\Models\Entity\Class' )->findOneBy( array( 'id' => 1 ) );
-var_dump( $data );
-
+$user     = $doctrine->em->getRepository(\App\Models\Entity\User::class)->find(1);
 ```
 
-## Usage as a Helper
+### As a helper
 
-In your BaseController - $helpers array, add an element with your helper filename.
+Add `doctrine_helper` to your `BaseController::$helpers`:
 
 ```php
-protected $helpers = [ 'doctrine_helper' ];
-
+protected $helpers = ['doctrine_helper'];
 ```
 
-And then, you can use the helper
-
 ```php
-
-$doctrine = doctrine_instance();
-$data = $doctrine->em->getRepository( 'App\Models\Entity\Class' )->findOneBy( array( 'id' => 1 ) );
-var_dump( $data );
-
+$doctrine  = doctrine_instance();             // default DB group
+$reporting = doctrine_instance('reporting');  // alternate DB group
 ```
 
-## Cli Commands
+### Constructing manually
 
 ```php
+$doctrine = new \Daycry\Doctrine\Doctrine();
+$user     = $doctrine->em->getRepository(\App\Models\Entity\User::class)->find(1);
+```
 
-//Mapping de database to entities classes
-php cli-config.php orm:convert-mapping --namespace="App\Models\Entity\" --force --from-database annotation .
+## Manual Result Caching
 
-//Generate getters & setters
+`getFromCacheOrQuery()` is autoloaded as a global function (no `use` is needed
+beyond the function import). It looks up `$cacheKey` in the configured result
+cache pool and falls back to the closure on miss.
+
+```php
+use function Daycry\Doctrine\Helpers\getFromCacheOrQuery;
+
+$rows = getFromCacheOrQuery(
+    cacheKey: 'projects_list_v1',
+    ttl: 300,
+    queryFn: fn () => $doctrine->em
+        ->createQueryBuilder()
+        ->select('p')
+        ->from(\App\Models\Entity\Project::class, 'p')
+        ->getQuery()
+        ->getArrayResult(),
+);
+```
+
+When the result cache is disabled (`Config\Doctrine::$resultsCache = false`)
+the closure runs every time. PSR-6 reserves the characters
+`{}()/\@:` in cache keys — avoid them.
+
+See [docs/usage.md](docs/usage.md) for advanced API: `getEm()`, `reOpen()`,
+multi-database groups, `Services::resetDoctrine()`, and more.
+
+## Doctrine ORM CLI
+
+Use the generated `cli-config.php` from the project root:
+
+```bash
+php cli-config.php orm:convert-mapping --namespace="App\Models\Entity\\" --force --from-database annotation .
 php cli-config.php orm:generate-entities .
-
-//Generate proxy classes
 php cli-config.php orm:generate-proxies app/Models/Proxies
-
 ```
-If you receive the followrin error:
-**[Semantical Error] The annotation "@JMS\Serializer\Annotation\ExclusionPolicy" in class App\Models\Entity\Secret was never imported. Did you maybe forget to add a "use" statement for this annotation?**
 
+If you encounter the JMS Serializer error *"The annotation
+@JMS\Serializer\Annotation\ExclusionPolicy was never imported"*, run
+`composer dump-autoload` to refresh annotation discovery.
 
-You must execute the following command
+## DataTables
 
 ```php
-    composer dump-autoload
+$datatables = (new \Daycry\Doctrine\DataTables\Builder())
+    ->withColumnAliases([
+        'id'   => 'p.id',
+        'name' => 'p.name',
+    ])
+    ->withSearchableColumns(['p.name'])
+    ->withCaseInsensitive(true)
+    ->withMaxFilterValues(500) // cap [IN] / [OR] value lists; default 500
+    ->withQueryBuilder(
+        $this->doctrine->em->createQueryBuilder()
+            ->select('p.id, p.name')
+            ->from(\App\Models\Entity\Project::class, 'p'),
+    )
+    ->withRequestParams($this->request->getGet());
+
+return $this->response->setJSON($datatables->getResponse());
 ```
 
-## Using DataTables
+If pagination throws *"Not all identifier properties can be found in the
+ResultSetMapping"*, set `->setUseOutputWalkers(false)` on the Builder.
 
-Usage with [doctrine/orm](https://github.com/doctrine/doctrine2):
------
-```php
+### Search modes
 
-$datatables = ( new \Daycry\Doctrine\DataTables\Builder() )
-            ->withColumnAliases(
-                [
-                    'id' => 'qlu.id'
-                ]
-            )
-            ->withIndexColumn( 'qlu.id' )
-            ->withQueryBuilder(
-                $this->doctrine->em->createQueryBuilder()
-                    ->select( 'qlu.param, q.param, q.param, qs.id as param, qlu.param, qlu.param' )
-                    ->from( \App\Models\Entity\Class::class, 'qlu' )
-                    ->innerJoin( \App\Models\Entity\Class::class, 'qs', \Doctrine\ORM\Query\Expr\Join::WITH, 'qs.id = qlu.*' )
-                    ->innerJoin( \App\Models\Entity\Class::class, 'ql', \Doctrine\ORM\Query\Expr\Join::WITH, 'ql.id = qlu.*' )
-                    ->innerJoin( \App\Models\Entity\Class::class, 'q', \Doctrine\ORM\Query\Expr\Join::WITH, 'q.id = ql.*' )
-            )
-            ->withRequestParams( $this->request->getGet( null ) );
-        
-        $response = $datatables->getResponse();
-
-        echo \json_encode( $response );
+The Builder supports bracket-prefixed operators per column:
 
 ```
-
-If you receive an error: **Not all identifier properties can be found in the ResultSetMapping** you can use:
-
-```php
-
-    ->setUseOutputWalkers( false )
-```
-## Example
-
-```php
-
-$datatables = ( new \Daycry\Doctrine\DataTables\Builder() )
-            ->withColumnAliases(
-                [
-                    'id' => 'qlu.id'
-                ]
-            )
-            ->withIndexColumn( 'qlu.id' )
-            ->setUseOutputWalkers( false )
-            ->withQueryBuilder(
-                $this->doctrine->em->createQueryBuilder()
-                    ->select( 'qlu.param, q.param, q.param, qs.id as param, qlu.param, qlu.param' )
-                    ->from( \App\Models\Entity\Class::class, 'qlu' )
-                    ->innerJoin( \App\Models\Entity\Class::class, 'qs', \Doctrine\ORM\Query\Expr\Join::WITH, 'qs.id = qlu.*' )
-                    ->innerJoin( \App\Models\Entity\Class::class, 'ql', \Doctrine\ORM\Query\Expr\Join::WITH, 'ql.id = qlu.*' )
-                    ->innerJoin( \App\Models\Entity\Class::class, 'q', \Doctrine\ORM\Query\Expr\Join::WITH, 'q.id = ql.*' )
-            )
-            ->withRequestParams( $this->request->getGet( null ) );
-        
-        $response = $datatables->getResponse();
-
-        echo \json_encode( $response );
-
+[%]   (LIKE, default)   [=]   [!=]   [>]   [<]   [IN]   [OR]   [><]
 ```
 
-## Search
+Synonyms `[LIKE]` and `[%%]` map to `[%]`. Unknown prefixes silently fall
+back to `[%]`. The DataTables `regex: true` flag is **not supported** —
+sending it raises `InvalidArgumentException`.
 
-To search from datatables there are nine different search modes
+See **[`docs/search_modes.md`](docs/search_modes.md)** for the full operator
+matrix, validation rules, case-insensitivity behaviour and examples.
 
-Mode | Pattern | Desctiption
--------- | ------------- | -----------
-**LIKE '…%'** | [*%]searchTerm | This performs a LIKE '…%' search where the start of the search term must match a value in the given column. This can be archived with only providing the search term (because it's default) or by prefixing the search term with "[*%]" ([*%]searchTerm).
-**LIKE '%…%'**| [%%]searchTerm | This performs a LIKE '%…%' search where any part the search term must match a value in the given column. This can be archived by prefixing the search term with "[%%]" ([%%]searchTerm).
-**Equality** | [=]searchTerm | This performs a = … search. The search term must exactly match a value in the given column. This can be archived by prefixing the search term with "[=]" ([=]searchTerm).
-**!= (No Equality)** | [!=]searchTerm | This performs a != … search. The search term must not exactly match a value in the given column. This can be archived by prefixing the search term with "[!=]" ([!=]searchTerm).
-**>** (Greater Than) | [>]searchTerm | This performs a > … search. The search term must be smaller than a value in the given column. This can be archived by prefixing the search term with "[>]" ([>]searchTerm).
-**<** (Smaller Than) | [<]searchTerm | This performs a < … search. The search term must be greater than a value in the given column. This can be archived by prefixing the search term with "[<]" ([<]searchTerm).
-**< (IN)** | [IN]searchTerm,searchTerm,… | This performs an IN(…) search. One of the provided comma-separated search terms must exactly match a value in the given column. This can be archived by prefixing the search terms with "[IN]" ([IN]searchTerm,searchTerm,…).
-**< (OR)** | [OR]searchTerm,searchTerm,… | This performs multiple OR-connected LIKE('%…%') searches. One of the provided comma-separated search terms must match a fragment of a value in the given column. This can be archived by prefixing the search terms with "[OR]" ([OR]searchTerm,searchTerm,…).
-**\>< (Between)** | [><]searchTerm,searchTerm | This performs a BETWEEN … AND … search. Both search terms must be separated with a comma. This operation can be archived by prefixing the comma-separated search terms with "[><]" ([><]searchTerm,searchTerm).
+## Debug Toolbar
 
-Prefixes are case-insenstive (IN, in, OR, or). Provided search terms were trimmed.
+A `DoctrineCollector` automatically captures every DBAL query so you can
+inspect them in the CodeIgniter Debug Toolbar.
 
-## Example
-
-```php
-
-public function testDataTableSearchColumnWithOr()
-    {
-        $doctrine = new \Daycry\Doctrine\Doctrine($this->config);
-        $request = \Config\Services::request();
-
-        $datatables = ( new \Daycry\Doctrine\DataTables\Builder() )
-            ->withColumnAliases(
-                [
-                    'id' => 't.id',
-                    'name' => 't.name'
-                ]
-            )
-            ->withIndexColumn('qlu.id')
-            ->setUseOutputWalkers(false)
-            ->withCaseInsensitive(false)
-            ->withColumnField('name')
-            ->withQueryBuilder(
-                $doctrine->em->createQueryBuilder()
-                    ->select('t.id, t.name')
-                    ->from(\Tests\Support\Models\Entities\Test::class, 't')
-            )
-            ->withRequestParams(
-                array(
-                    'draw' => 1,
-                    'start' => 0,
-                    'length' => 10,
-                    'search' => array('value' => '', 'regex' => true ),
-                    'columns' => array(
-                        array(
-                            'data' => 'id',
-                            'name' => 'id',
-                            'searchable' => true,
-                            'orderable' => true,
-                            'search' => array('value' => '[OR]1,3', 'regex' => false)
-                        ),
-                        array(
-                            'data' => 'name',
-                            'name' => 'name',
-                            'searchable' => true,
-                            'orderable' => true,
-                            'search' => array('value' => '', 'regex' => false)
-                        )
-                    ),
-                    'order' => array( array( 'column' => 0, 'dir' => 'asc') )
-                )
-            );
-
-        echo $response = json_encode($datatables->getResponse());
-
-    }
-```
-
-## Viewing Doctrine Queries in the Debug Toolbar
-
-This library allows you to view all SQL queries executed by Doctrine directly in the CodeIgniter 4 Debug Toolbar, making it easier to analyze and debug your database interactions.
-
-### How does it work?
-- A custom Collector (`DoctrineCollector`) and Middleware (`DoctrineQueryMiddleware`) are included to capture all queries executed by Doctrine.
-- The Middleware is automatically integrated when you instantiate `\Daycry\Doctrine\Doctrine`.
-- The Collector exposes the query information to the Toolbar, letting you see queries in real time.
-
-### Integration steps
-
-1. **Register the Collector in the Toolbar**
-
-   Open your `app/Config/Toolbar.php` file and add the Doctrine Collector to the `$collectors` array:
+1. Register the collector in `app/Config/Toolbar.php`:
 
    ```php
    public $collectors = [
-       // ...other collectors...
+       // ...
        \Daycry\Doctrine\Debug\Toolbar\Collectors\DoctrineCollector::class,
    ];
    ```
 
-2. **Use the Doctrine class as usual**
+2. Use Doctrine as usual — the middleware self-registers when you instantiate
+   the service.
 
-   When you instantiate `\Daycry\Doctrine\Doctrine` (as a service, helper, or manually), the Middleware is automatically enabled and queries will be captured.
+For long-running CLI workers you can cap the in-memory query log:
 
-3. **View queries in the Toolbar**
+```php
+\Config\Services::doctrineCollector()->setMaxQueries(500); // FIFO; 0 disables the cap
+```
 
-   Whenever you execute any query with Doctrine, you will see a new "Doctrine" tab in the CodeIgniter 4 Debug Toolbar, showing all SQL queries executed during the current request.
-
-### Notes and troubleshooting
-- You do not need to call any method manually to enable the Collector or Middleware.
-- If you do not see the "Doctrine" tab in the Toolbar, make sure the Collector is registered in `Toolbar.php` and that the Toolbar is enabled in your environment.
-- Fully compatible with advanced connections (SQLite3, SSL, custom options) and Doctrine DBAL 4+.
+See [docs/debug_toolbar.md](docs/debug_toolbar.md) for the full collector API,
+the SLC stats badge, and the per-request reset filter.
 
 ## Second-Level Cache (SLC)
 
-Doctrine's Second-Level Cache caches entities across requests using the same cache backend configured in `Config\Cache` (file, redis, memcached). No extra adapter configuration is required.
-
-Enable in `app/Config/Doctrine.php`:
+Doctrine's Second-Level Cache reuses the framework cache backend
+(file / Redis / Memcached / array) and its `ttl`. Enable in
+`app/Config/Doctrine.php`:
 
 ```php
 public bool $secondLevelCache           = true;
-public bool $secondLevelCacheStatistics = true;  // optional: show hits/misses/puts in the Debug Toolbar
+public bool $secondLevelCacheStatistics = true;  // optional: hits/misses/puts badge
 public ?int $secondLevelCacheTtl        = null;   // null = inherit Config\Cache::$ttl; 0 = no expiry
 ```
 
-See [docs/second_level_cache.md](docs/second_level_cache.md) for full details.
+To reset SLC statistics at the start of every request (useful in development
+to read per-request hit ratios in the toolbar), register the filter:
+
+```php
+// app/Config/Filters.php
+public array $globals = [
+    'before' => [
+        \Daycry\Doctrine\Debug\Filters\DoctrineSlcReset::class,
+    ],
+];
+```
+
+The filter is a no-op unless `secondLevelCacheStatistics` is enabled.
+
+See [docs/second_level_cache.md](docs/second_level_cache.md) and
+[docs/second_level_cache_stats.md](docs/second_level_cache_stats.md) for full
+details.
 
 ## Development
 
-Available composer scripts for contributors:
+Available Composer scripts for contributors:
 
 ```bash
-composer test          # Run PHPUnit test suite
-composer phpstan       # PHPStan static analysis (level 6)
+composer test          # PHPUnit test suite
+composer phpstan       # PHPStan (level 6)
 composer psalm         # Psalm static analysis
-composer rector        # Rector dry-run (code quality checks)
-composer analyze       # Run phpstan + psalm + rector
-composer cs            # PHP-CS-Fixer dry-run (check code style)
-composer cs-fix        # PHP-CS-Fixer apply fixes
+composer rector        # Rector dry-run
+composer analyze       # phpstan + psalm + rector
+composer cs            # PHP-CS-Fixer dry-run
+composer cs-fix        # PHP-CS-Fixer apply
 ```
+
+## License
+
+[MIT](LICENSE.md). Issues and PRs welcome at
+<https://github.com/daycry/doctrine>.

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,10 @@
     "autoload": {
         "psr-4": {
             "Daycry\\Doctrine\\": "src/"
-        }
+        },
+        "files": [
+            "src/Helpers/getFromCacheOrQuery.php"
+        ]
     },
     "autoload-dev":
     {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,32 +1,42 @@
 # Daycry Doctrine for CodeIgniter 4
 
-Modern integration of Doctrine ORM/DBAL into CodeIgniter 4, featuring:
+Modern integration of Doctrine ORM/DBAL into CodeIgniter 4. Highlights:
 
-- Robust query logging via Debug Toolbar (DoctrineCollector)
-- Cache adapters: file, Redis, Memcached, array (with runtime checks)
-- DataTables server-side builder with secure filtering and operators
-- Helpers for manual result caching and convenient service access
-- Comprehensive tests and docs
+- ORM bootstrap via `\Daycry\Doctrine\Doctrine` and `Services::doctrine()`
+- Server-side **DataTables Builder** with safe operators and `[><]` / `[IN]` / `[OR]` validation
+- **Debug Toolbar** collector with optional SLC stats and a per-request reset filter
+- **Second-Level Cache** wired to the framework cache backend
+- `getFromCacheOrQuery()` cache-aside helper
+- Multi-database group support (`Services::doctrine(true, 'reporting')`)
+- Comprehensive PHPUnit, PHPStan, Psalm and Rector coverage
 
 ## Documentation Index
 
-- `installation.md` — Install and enable the library
-- `configuration.md` — Publish and configure settings
-- `usage.md` — Services, helpers, and caching examples
-- `debug_toolbar.md` — Query logging and toolbar integration
-- `datatables.md` — DataTables integration, troubleshooting
-- `search_modes.md` — Per-column operator reference
-- `DATATABLES_FIX.md` — Details of the LIKE operator fix
-- `TEST_COVERAGE.md` — Testing and coverage overview
+- [installation.md](installation.md) — Install, autoload helper, optional Debug Toolbar setup
+- [configuration.md](configuration.md) — Publish and configure `Config\Doctrine`
+- [usage.md](usage.md) — Service / helper / direct, multi-DB, `getFromCacheOrQuery`, `reOpen()`, SLC reset
+- [cli_commands.md](cli_commands.md) — `doctrine:publish` and Doctrine ORM CLI
+- [datatables.md](datatables.md) — DataTables Builder API, examples, troubleshooting
+- [search_modes.md](search_modes.md) — Canonical reference of per-column operators
+- [debug_toolbar.md](debug_toolbar.md) — Query log + SLC badge + memory limits + reset filter
+- [second_level_cache.md](second_level_cache.md) — Doctrine SLC configuration
+- [second_level_cache_stats.md](second_level_cache_stats.md) — `StatisticsCacheLogger` API
+
+For breaking changes and a chronological list of additions see
+[`CHANGELOG.md`](../CHANGELOG.md) at the repository root.
 
 ## Quick Start
 
 ```php
+// As a service
 $doctrine = \Config\Services::doctrine();
-$em       = $doctrine->em;
 
-$repo = $em->getRepository(App\Models\Entity\WebProjects::class);
+// As a helper (after adding 'doctrine_helper' to BaseController::$helpers)
+$doctrine = doctrine_instance();
+
+$repo = $doctrine->em->getRepository(\App\Models\Entity\WebProjects::class);
 $item = $repo->findOneBy(['uuid' => $uuid]);
 ```
 
-For advanced usage, see the docs linked above.
+For advanced usage (multi-DB, manual caching, EntityManager re-opening,
+Debug Toolbar memory limits) see the documents linked above.

--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -1,35 +1,60 @@
 # CLI Commands
 
-Doctrine provides several CLI commands for working with your entities and database.
+The package exposes one CodeIgniter Spark command and ships a Doctrine ORM
+CLI bootstrap (`cli-config.php`).
 
-## Common Commands
+## Package Commands
 
-- **Mapping the database to entity classes:**
+### `doctrine:publish`
 
-  ```sh
-  php cli-config.php orm:convert-mapping --namespace="App\Models\Entity\\" --force --from-database annotation .
-  ```
-
-- **Generate getters & setters:**
-
-  ```sh
-  php cli-config.php orm:generate-entities .
-  ```
-
-- **Generate proxy classes:**
-
-  ```sh
-  php cli-config.php orm:generate-proxies app/Models/Proxies
-  ```
-
-If you receive the following error:
-
-```
-[Semantical Error] The annotation "@JMS\Serializer\Annotation\ExclusionPolicy" in class App\Models\Entity\Secret was never imported. Did you maybe forget to add a "use" statement for this annotation?
+```bash
+php spark doctrine:publish
 ```
 
-Run:
+Copies two files into your application:
+
+- `Config/Doctrine.php` → `app/Config/Doctrine.php` (extends
+  `Daycry\Doctrine\Config\Doctrine`).
+- `cli-config.php` → project root (used by the Doctrine ORM CLI below).
+
+Re-running the command prompts before overwriting an existing file. Type
+`n` at the prompt to abort safely; the command exits with status `1` to make
+this detectable in CI scripts.
+
+If you see *"APP_NAMESPACE not found in autoload psr4 configuration"*, ensure
+`composer.json`'s `autoload.psr-4` declares your `App\` namespace correctly,
+then run `composer dump-autoload`.
+
+## Doctrine ORM CLI
+
+These commands operate on the `cli-config.php` file generated above. Run them
+from the project root (where `cli-config.php` lives):
+
+```bash
+# Map an existing database to entity classes
+php cli-config.php orm:convert-mapping --namespace="App\Models\Entity\\" --force --from-database annotation .
+
+# Generate getters and setters
+php cli-config.php orm:generate-entities .
+
+# Generate proxy classes
+php cli-config.php orm:generate-proxies app/Models/Proxies
+```
+
+## Troubleshooting
+
+If you receive:
 
 ```
+[Semantical Error] The annotation "@JMS\Serializer\Annotation\ExclusionPolicy"
+in class App\Models\Entity\Secret was never imported. Did you maybe forget to
+add a "use" statement for this annotation?
+```
+
+run:
+
+```bash
 composer dump-autoload
 ```
+
+to refresh the annotation registry.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,74 +1,109 @@
 # Configuration
 
 ## Key Concepts
+
 - Config file: `app/Config/Doctrine.php` holds Doctrine integration settings.
-- Publish step: copies the config and CLI file into your app namespace.
-- Cache wiring: Query/Results/Metadata caches use the framework cache backend.
-- Second-Level Cache (SLC): toggled via a simple boolean; shares backend and TTL with `Config\Cache`.
+- Publish step: copies the config and CLI bootstrap into your app namespace.
+- Cache wiring: query / results / metadata caches share the framework cache backend (`Config\Cache`).
+- Second-Level Cache (SLC): toggled via a single boolean; reuses backend and TTL.
+- Multi-database: every `Config\Database` group maps to its own cached Doctrine instance — see [`usage.md`](usage.md#multi-database-groups).
 
-## Publish Configuration
+## Publishing the configuration
 
-After installation, publish the configuration files by running:
-
-```
+```bash
 php spark doctrine:publish
 ```
 
-This command copies the config file to your app namespace and a `cli-config.php` file for Doctrine CLI usage. By default, the config file is placed at `app/Config/Doctrine.php`.
+This copies `Config/Doctrine.php` into your app namespace and `cli-config.php`
+into the project root. Re-running the command prompts before overwriting
+existing files; choose `n` to abort safely.
 
-Adjust settings as needed for your project.
+## Options reference
 
-## Options overview
+### Proxies
 
-- `setAutoGenerateProxyClasses` (bool): Auto-generate proxies in development.
-- `entities` (array): Paths to your entity classes.
-- `proxies` (string): Directory for generated proxies.
-- `proxiesNamespace` (string): Namespace for generated proxies.
-- `proxyFactory` (bool): When `true` (default), use PHP 8.4+ native lazy objects as proxy factory if available; falls back to classic proxy generation otherwise.
-- `queryCache` / `resultsCache` / `metadataCache` (bool): Enable Doctrine caches backed by the framework cache.
-- `queryCacheNamespace` / `resultsCacheNamespace` / `metadataCacheNamespace` (string): Namespaces used by caches.
-- `metadataConfigurationMethod` (`attribute`|`xml`): Metadata driver to use.
-- `isXsdValidationEnabled` (bool): Enable XML schema validation when using XML mapping.
-- `secondLevelCache` (bool): Enable Doctrine Second-Level Cache. When true, SLC uses the same cache backend and `ttl` from `Config\Cache`.
-- `secondLevelCacheStatistics` (bool): Enable SLC hit/miss/put counters. When enabled, counters appear in the Debug Toolbar Doctrine panel and are accessible via `getSecondLevelCacheLogger()`.
-- `secondLevelCacheTtl` (?int): Override the SLC TTL in seconds. `null` = inherit from `Config\Cache::$ttl`; `0` = no expiration; `> 0` = custom TTL.
-- `customStringFunctions` / `customNumericFunctions` / `customDatetimeFunctions` / `customJsonFunctions` (array): Custom DQL functions registered with Doctrine. Pre-filled with `beberlei/doctrineextensions` and `scienta/doctrine-json-functions`.
-- `customTypeMappings` (array): Additional DBAL type mappings.
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `setAutoGenerateProxyClasses` | `bool` | `ENVIRONMENT === 'development'` | Auto-regenerates Doctrine proxies in development. |
+| `proxies` | `string` | `APPPATH . 'Models/Proxies'` | Filesystem path for generated proxies. |
+| `proxiesNamespace` | `string` | `'DoctrineProxies'` | Namespace assigned to generated proxies. |
+| `proxyFactory` | `bool` | `true` | On PHP ≥ 8.4 enables the engine's **native lazy objects** as proxy factory (skipping proxy class generation entirely). On PHP < 8.4 the flag has no effect — Doctrine falls back to generated proxies. Set to `false` to keep generated proxies even on PHP 8.4+ when running tools that don't yet support native lazy objects. |
 
-### Notes
-- No adapter needs to be configured for SLC in `Config\\Doctrine`; the library wires SLC to the framework cache backend automatically.
-- Ensure `entities` paths exist and are readable; misconfigured paths are validated early.
-- For Redis/Memcached, PHP extensions must be present; the service throws descriptive errors if missing.
+### Caches
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `queryCache` / `resultsCache` / `metadataCache` | `bool` | `true` | Toggle each Doctrine cache backed by `Config\Cache`. |
+| `queryCacheNamespace` / `resultsCacheNamespace` / `metadataCacheNamespace` | `string` | `doctrine_queries` / `doctrine_results` / `doctrine_metadata` | Namespace prefix for each cache pool. |
+
+### Metadata driver
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `metadataConfigurationMethod` | `'attribute'\|'xml'` | `'attribute'` | Which Doctrine metadata driver to use. |
+| `isXsdValidationEnabled` | `bool` | `false` | Enable XSD validation when `metadataConfigurationMethod = 'xml'`. |
+
+### Second-Level Cache (SLC)
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `secondLevelCache` | `bool` | `false` | Enable Doctrine SLC. Reuses `Config\Cache` backend and TTL. |
+| `secondLevelCacheStatistics` | `bool` | `false` | Collect hits/misses/puts via `StatisticsCacheLogger`. Surface them in the toolbar (and reset per request via the filter — see [`debug_toolbar.md`](debug_toolbar.md)). |
+| `secondLevelCacheTtl` | `?int` | `null` | Per-cache TTL override in seconds. `null` = inherit `Config\Cache::$ttl`. `0` = no expiration (entries persist until Doctrine invalidates them). `> 0` = custom TTL just for SLC. |
+
+### Custom DQL functions
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `customStringFunctions`, `customNumericFunctions`, `customDatetimeFunctions`, `customJsonFunctions` | `array<string, class-string>` | DQL extensions registered with Doctrine. Pre-filled with `beberlei/doctrineextensions` and `scienta/doctrine-json-functions`. Override or remove entries to disable specific functions. |
+
+### Type mappings
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `customTypeMappings` | `array<string, string>` | Native DBAL type → Doctrine type mappings registered on the database platform. Default: `['enum' => 'string', 'set' => 'string']`. Re-applied automatically on `Doctrine::reOpen()`. |
 
 ## Quick example
-
-Enable SLC in your `app/Config/Doctrine.php`:
 
 ```php
 <?php
 
 namespace App\Config;
 
-use CodeIgniter\Config\BaseConfig;
+use Daycry\Doctrine\Config\Doctrine as DoctrineBase;
 
-class Doctrine extends BaseConfig
+class Doctrine extends DoctrineBase
 {
-	public bool $setAutoGenerateProxyClasses = ENVIRONMENT === 'development';
-	public array $entities = [APPPATH . 'Models/Entity'];
-	public string $proxies = APPPATH . 'Models/Proxies';
-	public string $proxiesNamespace = 'DoctrineProxies';
+    public bool   $setAutoGenerateProxyClasses = ENVIRONMENT === 'development';
+    public array  $entities                    = [APPPATH . 'Models/Entity'];
+    public string $proxies                     = APPPATH . 'Models/Proxies';
+    public string $proxiesNamespace            = 'DoctrineProxies';
 
-	public bool $queryCache = true;
-	public string $queryCacheNamespace = 'doctrine_queries';
-	public bool $resultsCache = true;
-	public string $resultsCacheNamespace = 'doctrine_results';
-	public bool $metadataCache = true;
-	public string $metadataCacheNamespace = 'doctrine_metadata';
+    public bool   $queryCache              = true;
+    public bool   $resultsCache             = true;
+    public bool   $metadataCache            = true;
 
-	public string $metadataConfigurationMethod = 'attribute';
-	public bool $isXsdValidationEnabled = false;
+    public string $metadataConfigurationMethod = 'attribute';
+    public bool   $isXsdValidationEnabled      = false;
 
-	// Turn on Second-Level Cache; uses Config\Cache backend/ttl
-	public bool $secondLevelCache = true;
+    // SLC: enable + collect stats (separate booleans)
+    public bool $secondLevelCache           = true;
+    public bool $secondLevelCacheStatistics = true;  // optional
+
+    // Add a custom enum→Doctrine mapping if your DB uses enum columns
+    public array $customTypeMappings = [
+        'enum' => 'string',
+        'set'  => 'string',
+    ];
 }
 ```
+
+## Notes
+
+- No PSR-6 adapter has to be configured for SLC — the library wires the same
+  backend used by `Config\Cache` automatically.
+- If a Redis or Memcached extension is missing, the Doctrine service throws
+  `CacheException` with a descriptive message at construction.
+- For multi-database setups (`Services::doctrine(true, 'reporting')`), the
+  same `Config\Doctrine` is used for every group; each group resolves its own
+  Doctrine instance from `Config\Database->{$dbGroup}`.

--- a/docs/datatables.md
+++ b/docs/datatables.md
@@ -57,8 +57,10 @@ back to `[%]`.
 
 > **Important.** The DataTables `regex` flag (both `search.regex: true` and
 > `columns[N].search.regex: true`) is **not supported** and raises
-> `InvalidArgumentException: 'Regex search is not supported.'`. Use the
-> bracket operators instead.
+> `InvalidArgumentException: 'Regex search is not supported.'` whenever the
+> matching search value is non-empty. The flag is tolerated alongside an
+> empty value, since DataTables clients commonly include it in every
+> payload regardless of intent. Use the bracket operators instead.
 
 > **`[><]` strict arity.** `[><]min,max` requires *exactly* two
 > comma-separated values; sending one or three throws

--- a/docs/datatables.md
+++ b/docs/datatables.md
@@ -1,132 +1,151 @@
 # DataTables + Doctrine: Filtering and Search
 
-This module integrates DataTables with Doctrine ORM/DBAL, enabling dynamic pagination, ordering, and filtering on DQL queries.
+`Daycry\Doctrine\DataTables\Builder` provides server-side pagination, ordering
+and filtering for DataTables, built on top of a Doctrine `QueryBuilder`.
+
+For the canonical operator reference (modes, validation, exceptions) see
+[`search_modes.md`](search_modes.md). This document focuses on the Builder API
+and end-to-end examples.
 
 ## Key Concepts
 
-- `columnField`: which DataTables column property contains the identifier. Typical values: `data` or `name`.
-- `columnAliases`: maps DataTables columns to DQL fields (e.g., `name` → `t.name`).
-- `searchableColumns`: whitelist of columns used for global LIKE search. When set, only these columns are used in the global OR.
-- `withCaseInsensitive(true)`: enables case-insensitive matching for LIKE (both global and per-column when the operator is LIKE/`%` or `=`). It does not apply to non-LIKE operators (`IN`, `><`, `>`, `<`, `!=`).
+- `columnField` — which DataTables column property carries the field name.
+  Use `'data'` (default) when columns look like `{"data": "name"}`, or
+  `'name'` when they use `{"name": "name"}`.
+- `columnAliases` — maps DataTables identifiers to DQL paths
+  (`'name' => 't.name'`).
+- `searchableColumns` — whitelist of DQL fields used for the global LIKE
+  search. When set, only these columns participate in the global OR.
+- `withCaseInsensitive(true)` — wraps both the column and the parameter in
+  `lower()`. Applies only to LIKE-based searches (default `[%]`, `[OR]`)
+  and equality `[=]`. Operators `[IN]`, `[><]`, `[>]`, `[<]`, `[!=]` are
+  always case-sensitive.
 
 ## Builder API
 
 | Method | Description |
 |--------|-------------|
-| `Builder::create()` | Static factory. |
-| `withQueryBuilder($qb)` | Set the base DQL `QueryBuilder`. |
-| `withRequestParams(array $params)` | Set the DataTables request parameters. |
-| `withColumnAliases(array $aliases)` | Map DataTables column names to DQL paths. |
-| `withColumnField(string $field)` | DataTables column property used as field name (`data` or `name`). Default: `data`. |
-| `withSearchableColumns(array $cols)` | Whitelist DQL fields for global LIKE search. |
-| `withCaseInsensitive(bool $flag)` | Enable case-insensitive LIKE via `lower()`. |
+| `Builder::create()` | Static factory; equivalent to `new Builder()`. |
+| `withQueryBuilder($qb)` | Set the base DQL `QueryBuilder` (ORM or DBAL). |
+| `withRequestParams(array $params)` | Set the DataTables request payload. |
+| `withColumnAliases(array $aliases)` | Map DataTables column identifiers to DQL paths. |
+| `withColumnField(string $field)` | DataTables column property used as field name (`'data'` or `'name'`). |
+| `withSearchableColumns(array $cols)` | Whitelist DQL fields for the global LIKE search. |
+| `withCaseInsensitive(bool $flag)` | Enable case-insensitive LIKE / equality via `lower()`. |
 | `withIndexColumn(string $col)` | Override the index column used in pagination. |
-| `withMaxFilterValues(int $max)` | Maximum number of values accepted by `[IN]` and `[OR]` filters. Throws `InvalidArgumentException` if `< 1`. Use `PHP_INT_MAX` to disable. Default: 500. |
-| `setUseOutputWalkers(bool $flag)` | Control Doctrine `Paginator` output walkers. Set to `false` when pagination fails with scalar-select queries. |
+| `withMaxFilterValues(int $max)` | Cap the values accepted by `[IN]` and `[OR]`. Throws `InvalidArgumentException` if `< 1`. Use `PHP_INT_MAX` to disable. **Default: 500**, intended as a DoS guard. |
+| `setUseOutputWalkers(bool $flag)` | Toggle Doctrine `Paginator` output walkers. Set `false` when pagination fails with scalar-select queries (eg. *"Not all identifier properties can be found in the ResultSetMapping"*). |
 | `getData()` | Execute and return the paginated, filtered, ordered result. |
-| `getRecordsFiltered()` | Count of records matching the current filters (without pagination). |
-| `getRecordsTotal()` | Total count of records without any filter applied. |
+| `getRecordsFiltered()` | Count records matching the current filters (no pagination). |
+| `getRecordsTotal()` | Count records with no filter applied. |
 | `getResponse()` | Return the full DataTables response array (`draw`, `recordsTotal`, `recordsFiltered`, `data`). |
 
-## Supported Per-Column Operators
+## Per-Column Operators
 
-Column filters accept a bracket-prefixed operator in the value. Format: `[OPERATOR]value`. If the operator is not recognized, `%` (LIKE) is used by default.
+Column filters accept a bracket-prefixed operator: `[OPERATOR]value`. The
+canonical reference, including limits, exceptions and case-insensitivity
+rules, lives in **[`search_modes.md`](search_modes.md)**.
 
-| Mode                   | Pattern             | Description                                                                                 |
-|------------------------|---------------------|---------------------------------------------------------------------------------------------|
-| LIKE '%…%' (default)   | `[%]term` or `term` | LIKE '%term%'; any part of the term may match a value in the column.                        |
-| Equality               | `[=]term`           | Exact match: column = term.                                                                 |
-| Not Equal              | `[!=]term`          | Not equal: column != term.                                                                  |
-| Greater Than           | `[>]number`         | Greater than: column > number.                                                              |
-| Less Than              | `[<]number`         | Less than: column < number.                                                                 |
-| IN list                | `[IN]a,b,c`         | IN list: one of the comma-separated terms must exactly match.                               |
-| OR (LIKE-group)        | `[OR]a,b,c`         | OR of LIKE '%…%' for each term: column LIKE '%a%' OR '%b%' OR '%c%'.                        |
-| BETWEEN range          | `[><]min,max`       | Range: column BETWEEN min AND max.                                                          |
-| LIKE synonyms          | `[LIKE]term`, `[%%]term` | Synonyms for LIKE '%term%'.                                                             |
+Quick recap of the operators supported by the Builder:
 
-Notes:
-- For `[OR]`, the builder uses one LIKE per term; if `withCaseInsensitive(true)` is enabled, `lower()` is applied to the column and to the corresponding parameter.
-- Operators that do not use LIKE (`IN`, `><`, `>`, `<`, `!=`) are unaffected by `withCaseInsensitive(true)`.
+```
+[%]   (LIKE, default)   [=]   [!=]   [>]   [<]   [IN]   [OR]   [><]
+```
+
+Synonyms `[LIKE]` and `[%%]` map to `[%]`. Unknown prefixes silently fall
+back to `[%]`.
+
+> **Important.** The DataTables `regex` flag (both `search.regex: true` and
+> `columns[N].search.regex: true`) is **not supported** and raises
+> `InvalidArgumentException: 'Regex search is not supported.'`. Use the
+> bracket operators instead.
+
+> **`[><]` strict arity.** `[><]min,max` requires *exactly* two
+> comma-separated values; sending one or three throws
+> `InvalidArgumentException` (it no longer fails silently).
 
 ## Column Validation
 
-- If a column value is numeric or does not match a valid DQL identifier, it is ignored to avoid errors (e.g., `data='0'`).
-- Use `columnAliases` to map friendly DataTables names to DQL paths: `{ 'id': 't.id', 'name': 't.name' }`.
+- A column whose `data` is numeric or doesn't match
+  `^[A-Za-z_][\w.]*$` is dropped from `WHERE` and `ORDER BY` to prevent
+  malformed DQL (this is the historic *"6 LIKE :search"* failure).
+- Use `columnAliases` to map friendly DataTables identifiers to DQL paths.
 
 ## Examples
 
 ### Global Search (LIKE)
+
 ```php
 $builder
-  ->withSearchableColumns(['t.name'])
-  ->withCaseInsensitive(true)
-  ->withColumnField('data')
-  ->withRequestParams([
-    'search' => ['value' => 'am', 'regex' => false],
+    ->withSearchableColumns(['t.name'])
+    ->withCaseInsensitive(true)
+    ->withColumnField('data')
+    ->withRequestParams([
+        'search'  => ['value' => 'am', 'regex' => false],
+        'columns' => [
+            ['data' => 'id',   'searchable' => true],
+            ['data' => 'name', 'searchable' => true],
+        ],
+    ]);
+```
+
+Returns rows where `t.name` contains `"am"` (case-insensitive).
+
+### Per-Column `[IN]`
+
+```php
+$builder->withRequestParams([
     'columns' => [
-      ['data' => 'id', 'searchable' => true],
-      ['data' => 'name', 'searchable' => true]
+        ['data' => 'id',   'searchable' => true, 'search' => ['value' => '[IN]1,2,3']],
+        ['data' => 'name', 'searchable' => true, 'search' => ['value' => '']],
     ],
-  ]);
-```
-Returns rows where `t.name` contains "am".
-
-### Per-Column Filter with `IN`
-```php
-$builder->withRequestParams([
-  'columns' => [
-    ['data' => 'id', 'searchable' => true, 'search' => ['value' => '[IN]1,2'] ],
-    ['data' => 'name', 'searchable' => true, 'search' => ['value' => ''] ],
-  ]
 ]);
 ```
 
-### Per-Column Filter with `OR`
+### Per-Column `[OR]`
+
 ```php
 $builder->withRequestParams([
-  'columns' => [
-    ['data' => 'name', 'searchable' => true, 'search' => ['value' => '[OR]name1,name2'] ],
-  ]
+    'columns' => [
+        ['data' => 'name', 'searchable' => true, 'search' => ['value' => '[OR]alpha,beta']],
+    ],
 ]);
 ```
 
-### Filter with `BETWEEN`
+### `[><]` BETWEEN
+
 ```php
 $builder->withRequestParams([
-  'columns' => [
-    ['data' => 'id', 'searchable' => true, 'search' => ['value' => '[><]1,2'] ],
-  ]
+    'columns' => [
+        ['data' => 'price', 'searchable' => true, 'search' => ['value' => '[><]10,99']],
+    ],
 ]);
+// Sending '[><]10' or '[><]1,2,3' raises InvalidArgumentException.
 ```
 
-### Invalid Operator → Fallback to LIKE
+### Invalid Operator Falls Back to LIKE (silent)
+
 ```php
 $builder->withRequestParams([
-  'columns' => [
-    ['data' => 'name', 'searchable' => true, 'search' => ['value' => '[XYZ]am'] ],
-  ]
+    'columns' => [
+        ['data' => 'name', 'searchable' => true, 'search' => ['value' => '[XYZ]am']],
+    ],
 ]);
-// Interpreted as LIKE "%am%"
+// Equivalent to LIKE '%[XYZ]am%' — useful to know when debugging silent matches.
 ```
 
 ## Best Practices
 
-- Configure `columnAliases` and ensure entities/joins are properly defined so DQL identifiers are valid.
-- Define `searchableColumns` to constrain global search and avoid LIKE on unintended columns.
+- Configure `columnAliases` and ensure entities/joins are properly defined
+  so DQL identifiers are valid.
+- Define `searchableColumns` to constrain global search to safe text columns.
 - Avoid sending numeric indices in `data` as column identifiers.
-- Use `withCaseInsensitive(true)` when you expect mixed capitalization in search terms.
+- Use `withCaseInsensitive(true)` only when you actually want case-insensitive
+  matching — it does not affect `[IN]`, `[><]`, `[!=]`, `[>]`, `[<]`.
+- Tune `withMaxFilterValues()` to a value matching your business rules; the
+  default 500 prevents accidental DoS via huge `[IN]` lists.
 
-## Test References
-
-Tests in `tests/DataTableTest.php` cover:
-- Global and per-column search.
-- Operators `[IN]`, `[OR]`, `[><]`, `[=]`, `[!=]`, `[%]` and synonyms.
-- Fallback to `[%]` for invalid operators.
-- Ignoring columns with invalid (numeric) identifiers.
-
-Doctrine integrates smoothly with DataTables to provide server-side pagination, ordering, and filtering using Doctrine ORM/DBAL.
-
-## Basic Usage
+## Full Example
 
 ```php
 use Daycry\Doctrine\DataTables\Builder;
@@ -134,14 +153,13 @@ use Doctrine\ORM\Query\Expr\Join;
 
 $qb = $this->doctrine->em->createQueryBuilder();
 $qb->select('p.uuid AS id, p.name AS name, p.companyName AS companyName, ps.name AS status, p.version AS version')
-   ->from(App\Models\Entity\WebProjects::class, 'p')
-   ->innerJoin(App\Models\Entity\WebProjectsStatuses::class, 'ps', Join::WITH, 'p.webProjectStatus = ps.id')
+   ->from(\App\Models\Entity\WebProjects::class, 'p')
+   ->innerJoin(\App\Models\Entity\WebProjectsStatuses::class, 'ps', Join::WITH, 'p.webProjectStatus = ps.id')
    ->andWhere('p.deletedAt IS NULL');
 
 $builder = Builder::create()
     ->withQueryBuilder($qb)
     ->withRequestParams($this->request->getGet())
-    // Map DataTables column names to DQL fields used in select
     ->withColumnAliases([
         'id'          => 'p.uuid',
         'name'        => 'p.name',
@@ -149,38 +167,27 @@ $builder = Builder::create()
         'status'      => 'ps.name',
         'version'     => 'p.version',
     ])
-    // Restrict global LIKE search to safe text columns
     ->withSearchableColumns(['p.name', 'p.companyName', 'ps.name'])
-    // Optional: case-insensitive matching
     ->withCaseInsensitive(true)
-    // Optional: disable OutputWalkers if your query includes complex selects
     ->setUseOutputWalkers(false);
 
-$response = $builder->getResponse();
-return $this->response->setJSON($response);
+return $this->response->setJSON($builder->getResponse());
 ```
 
 ## Troubleshooting
 
-- Error: `Not all identifier properties can be found in the ResultSetMapping`
-  - Use `->setUseOutputWalkers(false)` when your select includes scalar mappings or complex joins.
+- *"Not all identifier properties can be found in the ResultSetMapping"* —
+  scalar-select queries don't expose entity identifiers. Call
+  `setUseOutputWalkers(false)` on the Builder.
+- *"Expected =, <, <=, <>, >, >=, !=, got 'LIKE'"* — caused by an invalid
+  column identifier (eg. a numeric index `6`) leaking into the global
+  search. Always provide `withColumnAliases([...])` and
+  `withSearchableColumns([...])` so only valid DQL fields participate in
+  LIKE conditions.
 
-- Error: `Expected =, <, <=, <>, >, >=, !=, got 'LIKE'`
-  - This happens when an invalid column (e.g., numeric index `6`) is used in global search.
-  - Ensure you provide `->withColumnAliases([...])` and `->withSearchableColumns([...])` so only valid DQL fields participate in LIKE conditions.
-  - See `docs/DATATABLES_FIX.md` for the detailed explanation and the implemented fix.
+## Test References
 
-## Filtering Operators (per-column)
-
-In the per-column search box, you can prefix your term to apply an operator. Prefixes are case-insensitive and terms are trimmed.
-
-- `[=]value` : exact match
-- `[!=]value` : not equal
-- `[>]10` : greater than
-- `[<]10` : less than
-- `[%]term` : LIKE `'%term%'` (default if no operator)
-- `[IN]a,b,c` : `IN (a,b,c)` exact match list
-- `[OR]a,b,c` : `LIKE '%a%' OR LIKE '%b%' OR LIKE '%c%'`
-- `[><]min,max` : `BETWEEN min AND max`
-
-For the full matrix of search modes, see `docs/search_modes.md`.
+`tests/DataTableTest.php` and `tests/DataTablesBuilderEdgeCasesTest.php`
+cover global and per-column searches, every supported operator, fallback to
+`[%]` for unknown prefixes, the `[><]` arity validation, the regex rejection,
+and the numeric-column dropout.

--- a/docs/debug_toolbar.md
+++ b/docs/debug_toolbar.md
@@ -1,45 +1,108 @@
-## Viewing Doctrine Queries in the Debug Toolbar
+# Doctrine Queries in the Debug Toolbar
 
-This feature shows all SQL queries executed by Doctrine in the CodeIgniter 4 Debug Toolbar.
+This page documents the CodeIgniter Debug Toolbar collector that ships with
+the package, the in-memory query log limit, the SLC stats badge, and the
+per-request reset filter.
 
-### Key Concepts
-- Collector: `DoctrineCollector` renders queries in the toolbar.
-- Middleware: `DoctrineQueryMiddleware` captures DBAL queries automatically.
-- Activation: enabled when you instantiate `\Daycry\Doctrine\Doctrine`.
-- Optional SLC stats: when `Config\\Doctrine::$secondLevelCacheStatistics = true`, the toolbar shows Second-Level Cache counters.
-    - You can reset counters per-request via `\Config\Services::doctrine()->resetSecondLevelCacheStatistics()`.
+## Key Concepts
 
-### Setup
+- **Collector:** `Daycry\Doctrine\Debug\Toolbar\Collectors\DoctrineCollector`
+  renders the Doctrine tab in the toolbar.
+- **Middleware:** `Daycry\Doctrine\Debug\Toolbar\Collectors\DoctrineQueryMiddleware`
+  is wired into Doctrine's DBAL stack automatically when you instantiate
+  `\Daycry\Doctrine\Doctrine`. No manual setup required.
+- **SLC stats badge:** appears when
+  `Config\Doctrine::$secondLevelCacheStatistics = true`. The badge format is
+  `SLC:hits/misses/puts (ratio%)` and a small stats table is rendered above
+  the queries.
+
+## Setup
+
 1. Register the collector in `app/Config/Toolbar.php`:
+
    ```php
    public $collectors = [
-       // ... other collectors ...
+       // …other collectors…
        \Daycry\Doctrine\Debug\Toolbar\Collectors\DoctrineCollector::class,
    ];
    ```
-2. Instantiate Doctrine (service, helper, or direct). Middleware auto-registers.
-3. Optional: Reset SLC counters per request in development by adding the filter in `app/Config/Filters.php`:
 
-   ```php
-   public array $globals = [
-       'before' => [
-           // ... other filters ...
-           \Daycry\Doctrine\Debug\Filters\DoctrineSlcReset::class,
-       ],
-       'after' => [],
-   ];
-   ```
+2. Use Doctrine as usual — no extra method calls. The middleware self-registers
+   in `Doctrine::__construct()` and pushes every DBAL query into the
+   collector.
 
-### Usage
-- Execute any Doctrine queries; a "Doctrine" tab appears showing the captured SQL.
-- If SLC statistics are enabled, the tab title includes a badge `SLC:hits/misses/puts (ratio%)` and a small stats table appears above the queries.
+3. (Optional) reset SLC counters per request — see
+   [Resetting Stats per Request](#resetting-stats-per-request).
 
-### Notes
-- No extra method calls are required.
-- If the tab is missing, confirm the collector registration and that the toolbar is enabled.
-- Works with advanced connections (SQLite3, SSL, custom options) and Doctrine DBAL 4+.
-- SQL display includes parameter bindings and timing; hover tooltips provide extra context if enabled.
-- Queries executed by DataTables and cache lookups are also collected.
-- SLC stats rely on the Doctrine service exposing a statistics logger; if not available, the badge/table are omitted gracefully.
- - Counters can be reset programmatically as shown above to measure hit ratio per request.
- - The SLC stats table uses Debug Toolbar classes for compact layout.
+## Usage
+
+Run any Doctrine query (repository, DBAL, DataTables Builder, cache lookup …)
+and a *Doctrine* tab will appear in the toolbar with:
+
+- a count badge
+- per-query SQL, bound parameters and duration
+- (when SLC stats are on) an SLC summary table and a `SLC:n/m/p (r%)` badge
+
+## Memory Management
+
+The collector keeps every captured query in memory. For long-running CLI
+workers or queue consumers that share a process, cap the buffer:
+
+```php
+$collector = \Config\Services::doctrineCollector();
+$collector->setMaxQueries(500);  // default 1000; 0 disables the cap
+```
+
+When the cap is reached the **oldest** entry is dropped (FIFO) before the
+new query is appended.
+
+## Manual Reset (tests)
+
+To clear the buffer programmatically — typically between tests:
+
+```php
+$collector = \Config\Services::doctrineCollector();
+$collector->reset();
+```
+
+`reset()` also invalidates the memoised SLC stats payload.
+
+## Resetting Stats per Request
+
+`DoctrineSlcReset` is a CodeIgniter filter that calls
+`Services::doctrine()->resetSecondLevelCacheStatistics()` at the start of
+every request, so the toolbar shows hit/miss/put counts scoped to the
+current request.
+
+Register it in `app/Config/Filters.php`:
+
+```php
+public array $globals = [
+    'before' => [
+        // …other before-filters…
+        \Daycry\Doctrine\Debug\Filters\DoctrineSlcReset::class,
+    ],
+];
+```
+
+The filter is a no-op when:
+
+- `Config\Doctrine::$secondLevelCacheStatistics` is `false` (logger absent)
+- the Doctrine service has not been instantiated yet for this request
+
+It always returns `null` and never throws — the toolbar must never break the
+request pipeline.
+
+## Notes
+
+- The collector is fully compatible with advanced DBAL connections (SQLite3,
+  SSL, custom options) and Doctrine DBAL 4+.
+- If the *Doctrine* tab is missing, double-check that the collector is
+  registered in `Toolbar.php` and that the toolbar is enabled in your
+  environment.
+- SQL display includes parameter bindings and timing. Long statements are
+  shortened with a hover tooltip showing the full SQL.
+- Queries executed by DataTables and cache lookups (eg. `getFromCacheOrQuery`
+  on a miss) are also collected.
+- SLC stats rely on the Doctrine service exposing a `StatisticsCacheLogger`;
+  if it is not available the badge and table are omitted gracefully.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,55 +1,65 @@
 # Installation
 
 ## Key Concepts
-- Package: `daycry/doctrine` provides Doctrine integration for CodeIgniter 4.
-- Autoload: When installing manually, register the `Daycry\Doctrine` namespace in `app/Config/Autoload.php`.
+
+- Package: `daycry/doctrine` provides Doctrine ORM 3 integration for CodeIgniter 4.
+- Requirements: PHP ≥ 8.2, CodeIgniter ^4, Doctrine ORM ^3, Symfony Cache ^7.
+- Autoload: when installing manually, register the `Daycry\Doctrine` namespace in `app/Config/Autoload.php`.
 
 ## Via Composer
 
-Use Composer to install the package:
-
-```
+```bash
 composer require daycry/doctrine
 ```
 
+After installing, publish the configuration files:
+
+```bash
+php spark doctrine:publish
+```
+
+This generates `app/Config/Doctrine.php` and `cli-config.php` in the project
+root. See [`configuration.md`](configuration.md) for the available options.
+
 ## Manual Installation
 
-Download this repository and enable it by editing `app/Config/Autoload.php` and adding the `Daycry\Doctrine` namespace to the `$psr4` array. For example, if you copied it into `app/ThirdParty`:
+Download this repository and register the namespace in
+`app/Config/Autoload.php`. For example, when copied into `app/ThirdParty`:
 
 ```php
 $psr4 = [
-    'Config'      => APPPATH . 'Config',
-    APP_NAMESPACE => APPPATH,
-    'App'         => APPPATH,
-    'Daycry\Doctrine' => APPPATH .'ThirdParty/doctrine/src',
+    'Config'          => APPPATH . 'Config',
+    APP_NAMESPACE     => APPPATH,
+    'App'             => APPPATH,
+    'Daycry\Doctrine' => APPPATH . 'ThirdParty/doctrine/src',
 ];
 ```
 
+Composer installation is preferred — it keeps dependencies and the
+`autoload.files` entry for the helper function in sync (see below).
+
+## Helper Function Autoload
+
+`Daycry\Doctrine\Helpers\getFromCacheOrQuery()` is autoloaded as a global
+function via the package's `composer.json` `autoload.files` entry. No
+namespace registration is needed; just import it where you use it:
+
+```php
+use function Daycry\Doctrine\Helpers\getFromCacheOrQuery;
+```
+
+See [`usage.md`](usage.md) for the cache-aside example.
+
 ## Notes
-- Prefer Composer installation to ensure dependencies and autoloading are managed correctly.
-- After installation, run `php spark doctrine:publish` to publish configuration files.
 
-## Debug Toolbar Integration
+- For Redis/Memcached cache backends, the corresponding PHP extensions
+  (`ext-redis`, `ext-memcached`) must be installed; the Doctrine service
+  raises a descriptive `CacheException` on missing extensions.
+- Ensure every path listed in `Config\Doctrine::$entities` exists and is
+  readable; misconfigured paths fail fast at construction time.
 
-To view Doctrine queries in the CodeIgniter Debug Toolbar:
+## Debug Toolbar
 
-1. Register the collector in `app/Config/Toolbar.php`:
-   ```php
-   public $collectors = [
-       // ... other collectors ...
-       \Daycry\Doctrine\Debug\Toolbar\Collectors\DoctrineCollector::class,
-   ];
-   ```
-2. Instantiate Doctrine (service, helper, or direct). Middleware auto-registers.
-3. Optional (development): reset Second-Level Cache counters per request by adding the filter in `app/Config/Filters.php`:
-   ```php
-   public array $globals = [
-       'before' => [
-           // ... other filters ...
-           \Daycry\Doctrine\Debug\Filters\DoctrineSlcReset::class,
-       ],
-       'after' => [],
-   ];
-   ```
-
-If you enable `Config\Doctrine::$secondLevelCacheStatistics = true`, the Doctrine panel shows a badge `SLC:hits/misses/puts (ratio%)` and a small statistics table above the queries.
+The package ships a Debug Toolbar collector and an optional per-request reset
+filter for SLC statistics. See [`debug_toolbar.md`](debug_toolbar.md) for the
+collector + filter setup steps.

--- a/docs/search_modes.md
+++ b/docs/search_modes.md
@@ -11,8 +11,11 @@ supported by `Daycry\Doctrine\DataTables\Builder`. Other docs (`README.md`,
 - Operators not listed below silently fall back to `[%]` (LIKE `'%term%'`) — see
   [Unknown Operators](#unknown-operators) for the recognised list.
 - The DataTables `regex` flag is **not supported**. Sending `regex: true`
-  (global or per column) raises `InvalidArgumentException`. Use the bracket
-  operators below instead.
+  *together with a non-empty search value* (global or per-column) raises
+  `InvalidArgumentException`. The flag is tolerated when the value is
+  empty, since DataTables clients commonly send the flag as part of every
+  request payload regardless of whether they intend to filter. Use the
+  bracket operators below for any actual filtering.
 
 ## Operator Matrix
 
@@ -39,9 +42,13 @@ supported by `Daycry\Doctrine\DataTables\Builder`. Other docs (`README.md`,
   comma-separated values (`[><]min,max`). Sending `[><]50` or `[><]1,2,3`
   raises `InvalidArgumentException` — previously this failed silently.
 
-- **No regex.** Both `search.regex: true` (global) and `columns[N].search.regex: true`
-  (per column) raise `InvalidArgumentException`. The exception message points the
-  caller to the bracket-prefix alternatives.
+- **No regex.** `search.regex: true` (global) and `columns[N].search.regex: true`
+  (per-column) raise `InvalidArgumentException` **only when the matching
+  search value is non-empty** — i.e. when the regex flag would actually be
+  applied. The flag is tolerated alongside an empty value so the typical
+  DataTables client payload (which sends the flag for every column) does
+  not need to be sanitised. Use the bracket-prefix alternatives below for
+  any real filtering.
 
 - **DQL-safe field names.** Field identifiers go through `isValidDQLField()`. Numeric
   indices and identifiers with characters outside `[A-Za-z_][\w.]*` are silently
@@ -59,9 +66,9 @@ Recognised tokens:
 =    !=    <    >    %    %%    LIKE    IN    OR    ><
 ```
 
-A typo such as `[XYZ]term` or `[*%]term` is therefore treated as
-`LIKE '%[XYZ]term%'` or `LIKE '%[*%]term%'` — useful to know when debugging
-silent matches that look wrong.
+A typo such as `[XYZ]term` is therefore treated as `LIKE '%term%'` (the
+unknown bracket prefix is stripped before the LIKE is applied). The legacy
+`[*%]` mode behaves the same way — it falls back to `LIKE '%term%'`.
 
 ## Case-Insensitivity Rules
 

--- a/docs/search_modes.md
+++ b/docs/search_modes.md
@@ -1,26 +1,102 @@
 # DataTables Search Modes
 
-This document describes supported per-column search operators for the DataTables + Doctrine integration.
+This document is the **canonical reference** for the per-column operators
+supported by `Daycry\Doctrine\DataTables\Builder`. Other docs (`README.md`,
+`docs/datatables.md`) link here instead of duplicating the table.
 
 ## Key Concepts
 
-- Prefixes are case-insensitive and search terms are trimmed.
 - Operators are applied per column via the DataTables request `columns[*].search.value`.
-- Unknown operators default to LIKE '%term%'.
+- Prefixes are case-insensitive (`[in]` ≡ `[IN]`); search terms are trimmed.
+- Operators not listed below silently fall back to `[%]` (LIKE `'%term%'`) — see
+  [Unknown Operators](#unknown-operators) for the recognised list.
+- The DataTables `regex` flag is **not supported**. Sending `regex: true`
+  (global or per column) raises `InvalidArgumentException`. Use the bracket
+  operators below instead.
 
-| Mode                | Pattern                   | Description                                                                                         |
-|---------------------|---------------------------|-----------------------------------------------------------------------------------------------------|
-| LIKE '%…%' (default)| `[%]term` or `term`       | LIKE '%term%' search; any part of the term may match a value in the column.                         |
-| Equality            | `[=]term`                 | Exact match: column = term.                                                                         |
-| Not Equal           | `[!=]term`                | Not equal: column != term.                                                                          |
-| Greater Than        | `[>]number`               | Greater than: column > number.                                                                      |
-| Less Than           | `[<]number`               | Less than: column < number.                                                                         |
-| IN list             | `[IN]a,b,c`               | IN list: one of the comma-separated terms must exactly match.                                       |
-| OR (LIKE-group)     | `[OR]a,b,c`               | OR of LIKE '%…%' for each term: column LIKE '%a%' OR '%b%' OR '%c%'.                                |
-| BETWEEN range       | `[><]min,max`             | Range: column BETWEEN min AND max.                                                                  |
-| LIKE synonyms       | `[LIKE]term`, `[%%]term`  | Synonyms for LIKE '%term%'.                                                                         |
+## Operator Matrix
 
-## Notes
+| Mode                    | Pattern                              | Description                                                                                                                                                              |
+|-------------------------|--------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| LIKE `'%…%'` (default)  | `[%]term` or `term`                  | LIKE `'%term%'`; any substring match. Affected by `withCaseInsensitive(true)` (wraps column and parameter in `lower()`).                                                |
+| LIKE synonyms           | `[LIKE]term` · `[%%]term`            | Identical to `[%]`.                                                                                                                                                      |
+| Equality                | `[=]term`                            | Exact match: `column = term`. Affected by `withCaseInsensitive(true)`.                                                                                                  |
+| Not Equal               | `[!=]term`                           | `column != term`. **Always case-sensitive.**                                                                                                                            |
+| Greater Than            | `[>]term`                            | `column > term`. Always case-sensitive.                                                                                                                                  |
+| Less Than               | `[<]term`                            | `column < term`. Always case-sensitive.                                                                                                                                  |
+| IN list                 | `[IN]a,b,c`                          | `column IN (a, b, c)`. Always case-sensitive. Subject to `withMaxFilterValues()` cap.                                                                                  |
+| OR (LIKE-group)         | `[OR]a,b,c`                          | `column LIKE '%a%' OR LIKE '%b%' OR …`. Affected by `withCaseInsensitive(true)`. Subject to `withMaxFilterValues()` cap.                                                |
+| BETWEEN range           | `[><]min,max`                        | `column BETWEEN min AND max`. **Requires exactly 2 values**; throws `InvalidArgumentException` otherwise. Always case-sensitive.                                       |
 
-- Global search applies LIKE to configured text columns. Use `withSearchableColumns([...])` and `withColumnAliases([...])` to ensure valid fields.
-- Invalid or unknown operators default to LIKE '%term%'.
+## Limits & Validation
+
+- **`[IN]` and `[OR]` value cap.** Both operators reject lists with more values
+  than `Builder::withMaxFilterValues()` (default `500`). Exceeding the cap raises
+  `InvalidArgumentException`. Set `PHP_INT_MAX` to disable; values smaller than `1`
+  also throw.
+
+- **`[><]` strict arity.** The Between operator requires exactly two
+  comma-separated values (`[><]min,max`). Sending `[><]50` or `[><]1,2,3`
+  raises `InvalidArgumentException` — previously this failed silently.
+
+- **No regex.** Both `search.regex: true` (global) and `columns[N].search.regex: true`
+  (per column) raise `InvalidArgumentException`. The exception message points the
+  caller to the bracket-prefix alternatives.
+
+- **DQL-safe field names.** Field identifiers go through `isValidDQLField()`. Numeric
+  indices and identifiers with characters outside `[A-Za-z_][\w.]*` are silently
+  dropped from `WHERE`/`ORDER BY` to prevent malformed DQL (avoids the historic
+  *"Expected =, <, … got 'LIKE'"* error).
+
+## Unknown Operators
+
+If the prefix does not match any of the operators recognised below, the Builder
+silently falls back to `[%]` (LIKE `'%term%'`).
+
+Recognised tokens:
+
+```
+=    !=    <    >    %    %%    LIKE    IN    OR    ><
+```
+
+A typo such as `[XYZ]term` or `[*%]term` is therefore treated as
+`LIKE '%[XYZ]term%'` or `LIKE '%[*%]term%'` — useful to know when debugging
+silent matches that look wrong.
+
+## Case-Insensitivity Rules
+
+`withCaseInsensitive(true)` only affects operators that compile to LIKE or
+equality — i.e. **`[%]`, `[%%]`, `[LIKE]`, `[OR]` and `[=]`**. The remaining
+operators (`[!=]`, `[<]`, `[>]`, `[IN]`, `[><]`) are always case-sensitive.
+
+## Examples
+
+Per-column IN:
+
+```php
+'columns' => [
+    ['data' => 'id', 'searchable' => true, 'search' => ['value' => '[IN]1,2,3']],
+],
+```
+
+Per-column OR (LIKE group):
+
+```php
+'columns' => [
+    ['data' => 'name', 'searchable' => true, 'search' => ['value' => '[OR]alpha,beta']],
+],
+```
+
+BETWEEN range:
+
+```php
+'columns' => [
+    ['data' => 'price', 'searchable' => true, 'search' => ['value' => '[><]10,99']],
+],
+// Sending '[><]10' or '[><]1,2,3' throws InvalidArgumentException.
+```
+
+## Related
+
+- Builder API and global search: [datatables.md](datatables.md)
+- `withMaxFilterValues()` configuration: [datatables.md#builder-api](datatables.md)

--- a/docs/second_level_cache.md
+++ b/docs/second_level_cache.md
@@ -1,57 +1,78 @@
 # Doctrine Second-Level Cache (SLC)
 
-This library optionally integrates Doctrine's Second-Level Cache (SLC). When enabled, entities can be cached across requests to reduce database load and improve performance for read-mostly data.
+The library wires Doctrine's Second-Level Cache (SLC) to the framework cache
+backend. When enabled, entities can be cached across requests to reduce
+database load and improve performance for read-mostly data.
 
 ## Key Concepts
-- Enable: single boolean in `app/Config/Doctrine.php` (`public bool $secondLevelCache = true;`).
-- Backend: reuses the framework cache backend from `Config\Cache` (file, redis, memcached, array) and its `ttl`.
-- Factory: `DefaultCacheFactory` is set up automatically in `src/Doctrine.php`; no app code changes required.
-- Regions: Doctrine manages regions and invalidation internally when entities change.
- - Statistics (optional): enable counters with `public bool $secondLevelCacheStatistics = true;` and view them in the Debug Toolbar.
+
+- **Enable:** a single boolean in `app/Config/Doctrine.php`
+  (`public bool $secondLevelCache = true;`).
+- **Backend:** reuses the framework cache backend from `Config\Cache` — file,
+  Redis, Memcached or in-memory array — and its `ttl`.
+- **Factory:** `DefaultCacheFactory` is set up automatically in
+  `src/Doctrine.php`; no application code required.
+- **Regions:** Doctrine creates and invalidates regions automatically per
+  entity. Manual region naming is optional and only useful for granular
+  invalidation strategies.
+- **Statistics (optional):** enable counters via
+  `public bool $secondLevelCacheStatistics = true;`. See
+  [`second_level_cache_stats.md`](second_level_cache_stats.md) for the API
+  and [`debug_toolbar.md`](debug_toolbar.md#resetting-stats-per-request) for
+  the per-request reset filter.
 
 ## Enable and Configure
 
-Publish config if you haven't:
+Publish the config if you haven't already:
 
 ```bash
 php spark doctrine:publish
 ```
 
-Then edit `app/Config/Doctrine.php` and set (see also [Configuration](configuration.md)):
+Then edit `app/Config/Doctrine.php`:
 
 ```php
-public bool $secondLevelCache = true;
-public bool $secondLevelCacheStatistics = true; // optional: show SLC hits/misses/puts in the Debug Toolbar
+public bool $secondLevelCache           = true;
+public bool $secondLevelCacheStatistics = true; // optional
 ```
 
-No application code changes are required to wire the factory; `src/Doctrine.php` sets up `DefaultCacheFactory` using the same cache backend configured in `Config\Cache` (file/redis/memcached/array) and its `ttl`.
+## TTL Override
 
-## Notes
-- Ensure cache adapters are available (extensions for Redis/Memcached). The service throws descriptive errors if missing.
-- Lifetimes follow the framework `ttl` by default. You can override specifically for SLC using `public ?int $secondLevelCacheTtl` in `app/Config/Doctrine.php`:
-    - `null`: inherit framework cache `ttl` from `Config\Cache`.
-    - `0`: no expiration (entries persist until invalidated by Doctrine).
-    - `> 0`: set a custom TTL in seconds just for SLC.
+```php
+public ?int $secondLevelCacheTtl = null;
+```
+
+| Value | Behaviour |
+|-------|-----------|
+| `null` | Inherit `Config\Cache::$ttl` (default). |
+| `0`    | No expiration — entries persist until Doctrine invalidates them. |
+| `> 0`  | Custom SLC TTL in seconds (overrides `Config\Cache::$ttl` only for SLC). |
 
 ## Cache Key Namespace
 
-SLC entries use the framework cache prefix plus `doctrine_slc` as namespace root:
+SLC entries use the framework cache prefix plus `doctrine_slc` as namespace
+root:
 
 ```
 <cache prefix>doctrine_slc
 ```
 
-Within this namespace Doctrine creates internal region keys. Flushing or updating entities invalidates affected region entries automatically—no manual deletion is required.
+Within this namespace Doctrine creates internal region keys. Flushing or
+updating entities invalidates affected region entries automatically — manual
+deletion is not required and is generally discouraged.
 
 ## Mark Entities as Cacheable
 
-Use Doctrine attributes to mark cacheable entities and optionally define a region:
+Use Doctrine attributes to mark entities cacheable:
 
 ```php
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
-#[ORM\Cache(usage: 'READ_ONLY', region: 'default_region')]
+#[ORM\Cache(
+    usage: 'READ_ONLY',         // READ_ONLY | NONSTRICT_READ_WRITE | READ_WRITE
+    region: 'default_region',   // optional; omit to use the Doctrine default
+)]
 class Product
 {
     #[ORM\Id]
@@ -64,26 +85,35 @@ class Product
 }
 ```
 
-Common `usage` values:
-- `READ_ONLY`: fastest; use for immutable data.
-- `NONSTRICT_READ_WRITE`: allows concurrent reads with eventual consistency.
-- `READ_WRITE`: strict invalidation; slightly slower.
+`usage` semantics:
+
+- `READ_ONLY` — fastest; use for immutable reference data.
+- `NONSTRICT_READ_WRITE` — concurrent reads with eventual consistency.
+- `READ_WRITE` — strict invalidation; slightly slower under concurrency.
 
 ## Best Practices
 
-- Prefer `READ_ONLY` for reference/lookup tables.
-- Avoid caching highly volatile entities unless using `READ_WRITE` and proper invalidation.
-- Use distinct regions to separate concerns; lifetimes follow the framework `ttl`.
-- Verify cache adapter availability (extensions for Redis/Memcached) in your environment.
+- Prefer `READ_ONLY` for reference / lookup tables.
+- Avoid caching highly volatile entities unless using `READ_WRITE` and
+  knowing the invalidation cost.
+- Use distinct regions to separate concerns when needed; lifetimes follow
+  the framework `ttl` unless overridden via `secondLevelCacheTtl`.
+- Verify cache adapter availability (extensions for Redis / Memcached) in
+  every environment.
 
 ## Troubleshooting
 
-- If the SLC does not seem effective, ensure entities are annotated with `#[ORM\Cache(...)]` and queries aren’t bypassing the cache (e.g., custom hydrators).
-- With `file` adapter, ensure the framework's cache directory is writable.
-- For Redis/Memcached, confirm the PHP extensions are loaded and credentials in `Config\Cache` are correct.
-- To inspect raw keys: list entries filtered by the prefix plus `doctrine_slc`. Avoid manual deletion unless performing a full cache reset.
+- If SLC does not seem effective, ensure entities are annotated with
+  `#[ORM\Cache(...)]` and that queries are not bypassing the cache (eg.
+  custom hydrators, `setHint(Query::HINT_CACHE_ENABLED, false)`).
+- With the `file` adapter, ensure the framework's cache directory is
+  writable.
+- For Redis / Memcached, confirm the PHP extensions are loaded and the
+  credentials in `Config\Cache` are correct.
 
 ## See Also
 
-- Debug Toolbar integration and SLC stats badge/table: [Debug Toolbar](debug_toolbar.md)
-- How to enable and view counters programmatically: [SLC Statistics](second_level_cache_stats.md)
+- Toolbar integration and the `SLC: hits/misses/puts (ratio%)` badge:
+  [`debug_toolbar.md`](debug_toolbar.md)
+- Statistics API and counters reset:
+  [`second_level_cache_stats.md`](second_level_cache_stats.md)

--- a/docs/second_level_cache_stats.md
+++ b/docs/second_level_cache_stats.md
@@ -1,45 +1,85 @@
-# Second Level Cache Statistics
+# Second-Level Cache Statistics
+
+When `Config\Doctrine::$secondLevelCacheStatistics` is enabled, Doctrine
+collects per-region hit / miss / put counters via its native
+`Doctrine\ORM\Cache\Logging\StatisticsCacheLogger`. The library exposes the
+logger so you can read or reset the counters.
 
 ## Key Concepts
-- **Backend reuse:** Uses your framework cache backend (files/redis/memcached/array) as PSR-6 pool.
-- **Toggle:** Enable via `Config\Doctrine::$secondLevelCache = true`.
-- **TTL:** Controlled by `Config\Cache::$ttl` (default 3600s) and regions configuration.
-- **Statistics (optional):** Enable counters with `Config\Doctrine::$secondLevelCacheStatistics = true`.
+
+- **Backend reuse:** uses your framework cache backend (file / Redis /
+  Memcached / array) as PSR-6 pool.
+- **Toggle:** enable via `Config\Doctrine::$secondLevelCache = true` (TTL via
+  `Config\Cache::$ttl` by default — see [`configuration.md`](configuration.md)).
+- **Statistics:** enable counters with
+  `Config\Doctrine::$secondLevelCacheStatistics = true`.
 
 ## Enabling
+
 1. Configure your preferred cache handler in `Config\Cache`.
-2. In `Config\Doctrine`, set:
+2. In `Config\Doctrine`:
 
-```php
-public bool $secondLevelCache = true;
-public bool $secondLevelCacheStatistics = true; // optional
-```
+   ```php
+   public bool $secondLevelCache           = true;
+   public bool $secondLevelCacheStatistics = true; // optional
+   ```
 
-3. Mark entities/associations cacheable where needed using Doctrine ORM 3 annotations/attributes (e.g., `#[ORM\Cache]`).
+3. Mark entities cacheable with `#[ORM\Cache]` attributes — see
+   [`second_level_cache.md`](second_level_cache.md#mark-entities-as-cacheable).
 
-## Viewing Statistics
-When `secondLevelCacheStatistics` is enabled:
-- The Debug Toolbar `Doctrine` panel shows a compact badge `SLC:hits/misses/puts (ratio%)`.
-- Inside the panel, a small table lists `Hits`, `Misses`, and `Puts`.
-
-You can also access the logger programmatically:
+## Reading the Counters
 
 ```php
 $logger = \Config\Services::doctrine()->getSecondLevelCacheLogger();
-if ($logger !== null) {
-    $hits   = $logger->getHitCount();
-    $misses = $logger->getMissCount();
-    $puts   = $logger->getPutCount();
+// ?Doctrine\ORM\Cache\Logging\StatisticsCacheLogger
+
+if ($logger === null) {
+    // Statistics are not enabled (Config\Doctrine::$secondLevelCacheStatistics = false)
+    // or the configured logger is not a StatisticsCacheLogger.
+    return;
 }
+
+$hits   = $logger->getHitCount();
+$misses = $logger->getMissCount();
+$puts   = $logger->getPutCount();
+
+// Per-region:
+$regionHits = $logger->getRegionHitCount('your_region_name');
 ```
 
-To reset counters (e.g. at the start of a request):
+`StatisticsCacheLogger` is part of Doctrine ORM; refer to the
+[Doctrine ORM Cache documentation](https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/second-level-cache.html#cache-logging)
+for the full API.
+
+## Resetting the Counters
+
+To reset counters programmatically (useful at the start of a long-running
+worker, or in tests):
 
 ```php
 \Config\Services::doctrine()->resetSecondLevelCacheStatistics();
 ```
 
+The package also ships a CodeIgniter filter that performs this reset at the
+start of every HTTP request (so the toolbar shows per-request stats); see
+[`debug_toolbar.md`](debug_toolbar.md#resetting-stats-per-request) for the
+registration steps.
+
+## Viewing the Stats in the Toolbar
+
+When `secondLevelCacheStatistics` is enabled:
+
+- the Doctrine panel shows a compact badge `SLC:hits/misses/puts (ratio%)`
+- inside the panel a small table lists hits, misses and puts
+
+See [`debug_toolbar.md`](debug_toolbar.md) for the toolbar integration.
+
 ## Notes
-- Clear metadata/proxies after changing cacheable mappings to avoid stale state.
-- Associations require target entities to be cacheable for join caching to work.
-- If stats do not appear, ensure the toolbar is enabled and Doctrine service is initialized.
+
+- Clear metadata / proxies after changing the `#[ORM\Cache]` attributes of
+  an entity to avoid stale state.
+- Associations require the target entity to be cacheable for join caching
+  to work.
+- If stats do not appear in the toolbar, ensure the toolbar is enabled and
+  the Doctrine service has been instantiated at least once during the
+  request.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,68 +1,171 @@
 # Usage
 
 ## Key Concepts
-- Service: `\Config\Services::doctrine()` returns the `Daycry\Doctrine\Doctrine` instance.
-- Helper: `doctrine_instance()` convenience accessor when added to `BaseController` helpers.
-- EntityManager: available at `$doctrine->em` for repositories, queries, and SchemaTool.
+
+- **Service:** `\Config\Services::doctrine($getShared = true, ?string $dbGroup = null)` returns a shared `Daycry\Doctrine\Doctrine` keyed by the (lower-cased) DB group name.
+- **Helper:** `doctrine_instance(?string $dbGroup = null)` is a convenience wrapper around the service for use with the `doctrine_helper`.
+- **EntityManager access:** `$doctrine->em` (direct property) or `$doctrine->getEm()` (throws if not initialised).
+- **Multi-DB:** every `Config\Database` group resolves to its own cached Doctrine instance — see [Multi-Database Groups](#multi-database-groups).
 
 ## Loading the Library
 
 ```php
 $doctrine = new \Daycry\Doctrine\Doctrine();
-$data = $doctrine->em->getRepository('App\Models\Entity\Class')->findOneBy(['id' => 1]);
-var_dump($data);
+$user     = $doctrine->em->getRepository(\App\Models\Entity\User::class)->find(1);
 ```
 
 ## As a Service
 
 ```php
 $doctrine = \Config\Services::doctrine();
-$data = $doctrine->em->getRepository('App\Models\Entity\Class')->findOneBy(['id' => 1]);
-var_dump($data);
+$user     = $doctrine->em->getRepository(\App\Models\Entity\User::class)->find(1);
 ```
 
 ## As a Helper
 
-In your `BaseController` `$helpers` array, add your helper filename:
+In your `BaseController` `$helpers`:
 
 ```php
 protected $helpers = ['doctrine_helper'];
 ```
 
-Then use the helper:
+Then in any method:
 
 ```php
-$doctrine = doctrine_instance();
-$data = $doctrine->em->getRepository('App\Models\Entity\Class')->findOneBy(['id' => 1]);
-var_dump($data);
+$doctrine = doctrine_instance();              // default DB group
+$reporting = doctrine_instance('reporting');  // alternate DB group
 ```
 
-## Manual Result Caching with Doctrine
+## Accessing the EntityManager
 
-You can manually cache query results using the provided helper. This works for Doctrine 3.x/4.x and integrates with configured cache adapters (file, Redis, Memcached, array).
+The Doctrine wrapper exposes the underlying `EntityManagerInterface` two ways:
+
+```php
+$em = $doctrine->em;       // public property — nullable until the constructor finishes
+$em = $doctrine->getEm();  // throws RuntimeException if the EM is not initialised
+```
+
+Prefer `getEm()` in code paths where a `null` EntityManager would be a bug
+(eg. controllers / jobs); use the property for lightweight access in places
+where the constructor has clearly already run.
+
+## Reopening the Connection
+
+Long-running CLI workers and queue consumers occasionally end up with a
+closed `EntityManager` after a swallowed exception. Use:
+
+```php
+$doctrine->reOpen();
+```
+
+`reOpen()` rebuilds the `EntityManager` from the existing DBAL connection and
+re-applies every entry in `customTypeMappings`. It throws if `getEm()` is
+`null`.
+
+## Multi-Database Groups
+
+`Config\Database` may declare several database groups (`default`, `reporting`,
+`legacy`, …). Each group resolves to its own cached Doctrine instance:
+
+```php
+$default   = \Config\Services::doctrine();                 // 'default'
+$reporting = \Config\Services::doctrine(true, 'reporting');
+
+// Helper form:
+$reporting = doctrine_instance('reporting');
+```
+
+Group names are case-insensitive and stored in the singleton cache as
+`doctrine_<lowercase_group>`. Pass `false` for `$getShared` to force a fresh
+instance:
+
+```php
+$fresh = \Config\Services::doctrine(false, 'reporting'); // new every time
+```
+
+To drop a cached instance (eg. between tests):
+
+```php
+\Config\Services::resetDoctrine();             // drops 'doctrine_default'
+\Config\Services::resetDoctrine('reporting');  // drops 'doctrine_reporting'
+```
+
+## Manual Result Caching
+
+The library autoloads a global cache-aside helper backed by Doctrine's
+`resultsCache` PSR-6 pool:
 
 ```php
 use function Daycry\Doctrine\Helpers\getFromCacheOrQuery;
 
-$cacheKey = 'webprojects:list:v1';
-$ttl      = 300; // seconds
-
-$result = getFromCacheOrQuery(
-	cacheKey: $cacheKey,
-	ttl: $ttl,
-	queryFn: function () use ($doctrine) {
-		return $doctrine->em->createQueryBuilder()
-			->select('p')
-			->from(App\Models\Entity\WebProjects::class, 'p')
-			->andWhere('p.deletedAt IS NULL')
-			->getQuery()
-			->getArrayResult();
-	}
+$rows = getFromCacheOrQuery(
+    cacheKey: 'reports_daily',
+    ttl: 600,
+    queryFn: fn () => $em->createQuery(/* DQL */)->getArrayResult(),
 );
-
-// $result is cached on first call and reused until TTL expires
 ```
 
-### Notes
-- If a cache adapter is misconfigured or missing, the Doctrine service throws a descriptive error.
-- See `src/Doctrine.php` for runtime checks, cache wiring, and configuration details.
+Signature:
+
+```php
+function getFromCacheOrQuery(
+    string $cacheKey,
+    int $ttl,
+    callable $queryFn,
+    ?string $dbGroup = null,
+): mixed
+```
+
+- Looks up `$cacheKey` in `Config\Doctrine` `resultsCache` pool (`Config\Cache`
+  backend by default).
+- Cache miss → runs the closure, stores the value with `$ttl` seconds expiry
+  (`0` = no expiration), returns it.
+- Cache disabled (`Config\Doctrine::$resultsCache = false`) → always runs the
+  closure, returns its value, stores nothing.
+- `$dbGroup` selects the underlying Doctrine instance. Useful for
+  multi-tenant or read-replica setups:
+
+  ```php
+  $rows = getFromCacheOrQuery(
+      cacheKey: 'reports_daily',
+      ttl: 600,
+      queryFn: fn () => $em->createQuery(/* DQL */)->getArrayResult(),
+      dbGroup: 'reporting',
+  );
+  ```
+
+PSR-6 reserves `{}()/\@:` in cache keys — avoid them.
+
+## Second-Level Cache Statistics
+
+When `Config\Doctrine::$secondLevelCacheStatistics = true`, the wrapper
+exposes Doctrine's `StatisticsCacheLogger`:
+
+```php
+$logger = \Config\Services::doctrine()->getSecondLevelCacheLogger();
+// ?Doctrine\ORM\Cache\Logging\StatisticsCacheLogger
+
+if ($logger !== null) {
+    $hits   = $logger->getHitCount();
+    $misses = $logger->getMissCount();
+    $puts   = $logger->getPutCount();
+}
+```
+
+Reset the counters at the start of a request (eg. to read per-request hit
+ratios in the toolbar):
+
+```php
+\Config\Services::doctrine()->resetSecondLevelCacheStatistics();
+```
+
+The package also ships a filter that performs this reset automatically — see
+[`debug_toolbar.md`](debug_toolbar.md#resetting-stats-per-request) and
+[`second_level_cache_stats.md`](second_level_cache_stats.md).
+
+## Notes
+
+- If a cache adapter is misconfigured (missing extension, unreachable Redis
+  server, etc.) the Doctrine service raises `CacheException` at construction
+  with a descriptive message and the underlying error chained as `previous`.
+- See `src/Doctrine.php` for runtime checks, cache wiring, and SLC setup.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -32,9 +32,6 @@
 			<directory suffix=".php">./src</directory>
 		</include>
 		<exclude>
-			<directory suffix=".php">./src/Config</directory>
-			<directory suffix=".php">./src/Commands</directory>
-			<directory suffix=".php">./src/Cache</directory>
 			<file>./src/cli-config.php</file>
 		</exclude>
 	</source>

--- a/rector.php
+++ b/rector.php
@@ -16,7 +16,6 @@ use Rector\CodingStyle\Rector\ClassMethod\FuncGetArgsToVariadicParamRector;
 use Rector\CodingStyle\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsParentRector;
 use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\Config\RectorConfig;
-use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPromotedPropertyRector;
 use Rector\EarlyReturn\Rector\Foreach_\ChangeNestedForeachIfsToEarlyContinueRector;
 use Rector\EarlyReturn\Rector\If_\ChangeIfElseValueAssignToEarlyReturnRector;
 use Rector\EarlyReturn\Rector\If_\RemoveAlwaysElseRector;
@@ -29,7 +28,7 @@ use Rector\Set\ValueObject\SetList;
 use Rector\ValueObject\PhpVersion;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->sets([SetList::DEAD_CODE, LevelSetList::UP_TO_PHP_74, PHPUnitSetList::PHPUNIT_CODE_QUALITY, PHPUnitSetList::PHPUNIT_80]);
+    $rectorConfig->sets([SetList::DEAD_CODE, LevelSetList::UP_TO_PHP_82, PHPUnitSetList::PHPUNIT_CODE_QUALITY, PHPUnitSetList::PHPUNIT_100]);
     $rectorConfig->parallel();
     // The paths to refactor (can also be supplied with CLI arguments)
     $rectorConfig->paths([
@@ -52,7 +51,7 @@ return static function (RectorConfig $rectorConfig): void {
     }
 
     // Set the target version for refactoring
-    $rectorConfig->phpVersion(PhpVersion::PHP_74);
+    $rectorConfig->phpVersion(PhpVersion::PHP_82);
 
     // Auto-import fully qualified class names
     $rectorConfig->importNames();
@@ -63,19 +62,8 @@ return static function (RectorConfig $rectorConfig): void {
 
         StringifyStrNeedlesRector::class,
 
-        // Note: requires php 8
-        RemoveUnusedPromotedPropertyRector::class,
-
-        // Ignore tests that might make calls without a result
-        // RemoveEmptyMethodCallRector removed in current Rector version
-
-        // Ignore files that should not be namespaced
-        // NormalizeNamespaceByPSR4ComposerAutoloadRector removed in current Rector version
-
         // May load view files directly when detecting classes
         StringClassNameToClassConstantRector::class,
-
-        // May be uninitialized on purpose — AddDefaultValueForUndefinedVariableRector removed in current Rector version
     ]);
     $rectorConfig->rule(SimplifyUselessVariableRector::class);
     $rectorConfig->rule(RemoveAlwaysElseRector::class);

--- a/src/Commands/DoctrinePublish.php
+++ b/src/Commands/DoctrinePublish.php
@@ -44,7 +44,7 @@ class DoctrinePublish extends BaseCommand
         if ($this->sourcePath === '/' || empty($this->sourcePath)) {
             CLI::error('Unable to determine the correct source directory. Bailing.');
 
-            exit();
+            exit(1);
         }
     }
 
@@ -59,7 +59,7 @@ class DoctrinePublish extends BaseCommand
         if ($content === false) {
             CLI::error("Unable to read source file: {$path}");
 
-            exit();
+            exit(1);
         }
         $this->writeFile('../cli-config.php', $content);
     }
@@ -75,7 +75,7 @@ class DoctrinePublish extends BaseCommand
         if ($content === false) {
             CLI::error("Unable to read source file: {$path}");
 
-            exit();
+            exit(1);
         }
         $content = str_replace('namespace Daycry\\Doctrine\\Config', 'namespace Config', $content);
         $content = str_replace('extends BaseConfig', 'extends \\Daycry\\Doctrine\\Config\\Doctrine', $content);
@@ -94,7 +94,7 @@ class DoctrinePublish extends BaseCommand
         if ($appPath === null) {
             CLI::error('APP_NAMESPACE "' . APP_NAMESPACE . '" not found in autoload psr4 configuration.');
 
-            exit();
+            exit(1);
         }
         $directory = dirname($appPath . $path);
         if (! is_dir($directory)) {
@@ -103,7 +103,7 @@ class DoctrinePublish extends BaseCommand
         if (file_exists($appPath . $path) && CLI::prompt('Config file already exists, do you want to replace it?', ['y', 'n']) === 'n') {
             CLI::error('Cancelled');
 
-            exit();
+            exit(1);
         }
 
         try {
@@ -112,7 +112,7 @@ class DoctrinePublish extends BaseCommand
         } catch (Throwable $e) {
             $this->showError($e);
 
-            exit();
+            exit(1);
         }
         $path = str_replace($appPath, '', $path);
         CLI::write(CLI::color('Created: ', 'yellow') . $path);

--- a/src/DataTables/Builder.php
+++ b/src/DataTables/Builder.php
@@ -150,13 +150,17 @@ class Builder
         $columns = $this->requestParams['columns'];
         $c       = count($columns);
 
-        // Reject regex search mode — bracket-prefix operators must be used instead.
-        if (! empty($this->requestParams['search']['regex'])) {
+        // Reject regex search mode only when it would actually be applied (non-empty value).
+        // DataTables clients commonly send `regex` keys for every column even when the value is
+        // empty; raising on empty values would force callers to strip noise from their payload.
+        $globalSearchValue = trim((string) ($this->requestParams['search']['value'] ?? ''));
+        if ($globalSearchValue !== '' && ! empty($this->requestParams['search']['regex'])) {
             throw new InvalidArgumentException('Regex search is not supported. Use bracket-prefix operators like [IN], [OR], [><] instead.');
         }
 
         foreach ($columns as $column) {
-            if (! empty($column['search']['regex'] ?? null)) {
+            $columnSearchValue = trim((string) ($column['search']['value'] ?? ''));
+            if ($columnSearchValue !== '' && ! empty($column['search']['regex'] ?? null)) {
                 throw new InvalidArgumentException('Regex per-column search is not supported. Use bracket-prefix operators like [IN], [OR], [><] instead.');
             }
         }
@@ -320,9 +324,19 @@ class Builder
      */
     private function parseFilterOperator(string $raw): array
     {
-        $pattern  = '~^\[(?<operator>!=|><|>|<|=|%%|%|IN|OR|LIKE)\]~i';
-        $operator = preg_match($pattern, $raw, $m) ? strtoupper($m['operator']) : '%';
-        $value    = preg_replace($pattern, '', $raw);
+        $validPattern  = '~^\[(?<operator>!=|><|>|<|=|%%|%|IN|OR|LIKE)\]~i';
+        $bracketPrefix = '~^\[[^\]]+\]~';
+
+        if (preg_match($validPattern, $raw, $m)) {
+            $operator = strtoupper($m['operator']);
+            $value    = preg_replace($validPattern, '', $raw);
+        } else {
+            // Unknown bracket prefixes (typos like "[XYZ]") fall back to LIKE; the
+            // prefix itself is stripped so the user-facing search term works as-is.
+            $operator = '%';
+            $value    = preg_replace($bracketPrefix, '', $raw);
+        }
+
         // Normalize synonyms
         if ($operator === 'LIKE' || $operator === '%%') {
             $operator = '%';

--- a/src/DataTables/Builder.php
+++ b/src/DataTables/Builder.php
@@ -150,6 +150,17 @@ class Builder
         $columns = $this->requestParams['columns'];
         $c       = count($columns);
 
+        // Reject regex search mode — bracket-prefix operators must be used instead.
+        if (! empty($this->requestParams['search']['regex'])) {
+            throw new InvalidArgumentException('Regex search is not supported. Use bracket-prefix operators like [IN], [OR], [><] instead.');
+        }
+
+        foreach ($columns as $column) {
+            if (! empty($column['search']['regex'] ?? null)) {
+                throw new InvalidArgumentException('Regex per-column search is not supported. Use bracket-prefix operators like [IN], [OR], [><] instead.');
+            }
+        }
+
         // Search
         if (array_key_exists('search', $this->requestParams)) {
             $value = mb_substr(trim($this->requestParams['search']['value'] ?? ''), 0, 255);
@@ -269,11 +280,15 @@ class Builder
 
                     case '><':
                         $valueArr = explode(',', $value);
-                        if (count($valueArr) === 2) {
-                            $andX->add($query->expr()->between($fieldName, ":filter_{$i}_0", ":filter_{$i}_1"));
-                            $query->setParameter("filter_{$i}_0", trim($valueArr[0]));
-                            $query->setParameter("filter_{$i}_1", trim($valueArr[1]));
+                        if (count($valueArr) !== 2) {
+                            throw new InvalidArgumentException(sprintf(
+                                'BETWEEN operator [><] requires exactly 2 comma-separated values, got %d.',
+                                count($valueArr),
+                            ));
                         }
+                        $andX->add($query->expr()->between($fieldName, ":filter_{$i}_0", ":filter_{$i}_1"));
+                        $query->setParameter("filter_{$i}_0", trim($valueArr[0]));
+                        $query->setParameter("filter_{$i}_1", trim($valueArr[1]));
                         break;
 
                     case '=':
@@ -305,18 +320,15 @@ class Builder
      */
     private function parseFilterOperator(string $raw): array
     {
-        $operator = preg_match('~^\[(?<operator>[A-Z!=%<>•]+)\]~i', $raw, $m) ? strtoupper($m['operator']) : '%';
-        $value    = preg_replace('~^\[[A-Z!=%<>•]+\]~i', '', $raw);
+        $pattern  = '~^\[(?<operator>!=|><|>|<|=|%%|%|IN|OR|LIKE)\]~i';
+        $operator = preg_match($pattern, $raw, $m) ? strtoupper($m['operator']) : '%';
+        $value    = preg_replace($pattern, '', $raw);
         // Normalize synonyms
-        if (in_array($operator, ['LIKE', '%%'], true)) {
-            $operator = '%';
-        }
-        $valid = ['!=', '<', '>', 'IN', 'OR', '><', '=', '%'];
-        if (! in_array($operator, $valid, true)) {
+        if ($operator === 'LIKE' || $operator === '%%') {
             $operator = '%';
         }
 
-        return [$operator, trim($value)];
+        return [$operator, trim($value ?? $raw)];
     }
 
     /**

--- a/src/Debug/Filters/DoctrineSlcReset.php
+++ b/src/Debug/Filters/DoctrineSlcReset.php
@@ -7,17 +7,39 @@ namespace Daycry\Doctrine\Debug\Filters;
 use CodeIgniter\Filters\FilterInterface;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
+use Daycry\Doctrine\Config\Services;
+use Throwable;
 
+/**
+ * Resets Second-Level Cache statistics counters at the start of every request,
+ * so the Debug Toolbar shows hits/misses/puts scoped to the current request.
+ *
+ * Register in `app/Config/Filters.php`:
+ *
+ *     public array $globals = [
+ *         'before' => [
+ *             \Daycry\Doctrine\Debug\Filters\DoctrineSlcReset::class,
+ *         ],
+ *     ];
+ *
+ * Has no effect when `Config\Doctrine::$secondLevelCacheStatistics` is disabled
+ * or the Doctrine service has not yet been instantiated.
+ */
 class DoctrineSlcReset implements FilterInterface
 {
     public function before(RequestInterface $request, $arguments = null): RequestInterface|ResponseInterface|string|null
     {
+        try {
+            Services::doctrine()->resetSecondLevelCacheStatistics();
+        } catch (Throwable) {
+            // Toolbar filter must never break the request pipeline.
+        }
+
         return null;
     }
 
     public function after(RequestInterface $request, ResponseInterface $response, $arguments = null): ?ResponseInterface
     {
-        // no-op
         return null;
     }
 }

--- a/src/Debug/Toolbar/Collectors/DoctrineCollector.php
+++ b/src/Debug/Toolbar/Collectors/DoctrineCollector.php
@@ -22,7 +22,26 @@ class DoctrineCollector extends BaseCollector
     protected ?StatisticsCacheLogger $slcLogger = null;
 
     /**
-     * Queries ejecutadas
+     * Cached resolved SLC logger (separate sentinel: false = not yet resolved).
+     */
+    private false|StatisticsCacheLogger|null $resolvedLogger = false;
+
+    /**
+     * Cached payload returned by getData() to avoid duplicate Service lookups
+     * during a single render (isEmpty() then display() call it).
+     *
+     * @var array<string, mixed>|null
+     */
+    private ?array $cachedData = null;
+
+    /**
+     * Maximum number of queries to keep in memory. Older entries are dropped
+     * (FIFO) once the cap is reached. Use 0 to disable the cap.
+     */
+    protected int $maxQueries = 1000;
+
+    /**
+     * Queries collected during the request.
      *
      * @var array<int, array<string, mixed>>
      */
@@ -33,7 +52,16 @@ class DoctrineCollector extends BaseCollector
      */
     public function addQuery(array $query): void
     {
-        $this->queries[] = $query;
+        if ($this->maxQueries > 0 && count($this->queries) >= $this->maxQueries) {
+            array_shift($this->queries);
+        }
+        $this->queries[]  = $query;
+        $this->cachedData = null;
+    }
+
+    public function setMaxQueries(int $maxQueries): void
+    {
+        $this->maxQueries = max(0, $maxQueries);
     }
 
     /**
@@ -41,7 +69,9 @@ class DoctrineCollector extends BaseCollector
      */
     public function reset(): void
     {
-        $this->queries = [];
+        $this->queries        = [];
+        $this->cachedData     = null;
+        $this->resolvedLogger = false;
     }
 
     /**
@@ -49,7 +79,9 @@ class DoctrineCollector extends BaseCollector
      */
     public function setSecondLevelCacheLogger(StatisticsCacheLogger $logger): void
     {
-        $this->slcLogger = $logger;
+        $this->slcLogger      = $logger;
+        $this->resolvedLogger = false;
+        $this->cachedData     = null;
     }
 
     /**
@@ -75,38 +107,55 @@ class DoctrineCollector extends BaseCollector
         $queryCount = count($this->queries);
         $details    = $queryCount > 0 ? "({$queryCount} quer" . ($queryCount > 1 ? 'ies' : 'y') . ')' : '';
 
-        // Append compact SLC badge if enabled
-        try {
-            $logger = $this->slcLogger;
-            if ($logger === null && class_exists('Config\\Services') && method_exists(Services::class, 'doctrine')) {
-                $doctrine = Services::doctrine();
-                if (method_exists($doctrine, 'getSecondLevelCacheLogger')) {
-                    $logger = $doctrine->getSecondLevelCacheLogger();
-                }
-            }
-            if ($logger !== null) {
-                $hits     = $logger->getHitCount();
-                $misses   = $logger->getMissCount();
-                $puts     = $logger->getPutCount();
-                $total    = $hits + $misses;
-                $ratio    = $total > 0 ? round(($hits / $total) * 100) : 0;
-                $slcBadge = ' SLC:' . $hits . '/' . $misses . '/' . $puts . ' (' . $ratio . '%)';
-                $details  = trim($details . $slcBadge);
-            }
-        } catch (Throwable $e) {
-            // ignore
+        $logger = $this->resolveSlcLogger();
+        if ($logger !== null) {
+            $hits     = $logger->getHitCount();
+            $misses   = $logger->getMissCount();
+            $puts     = $logger->getPutCount();
+            $total    = $hits + $misses;
+            $ratio    = $total > 0 ? round(($hits / $total) * 100) : 0;
+            $slcBadge = ' SLC:' . $hits . '/' . $misses . '/' . $puts . ' (' . $ratio . '%)';
+            $details  = trim($details . $slcBadge);
         }
 
         return $details;
     }
 
+    /**
+     * Resolve and memoize the Second-Level Cache logger.
+     * Returns null when SLC stats are not enabled or not yet wired up.
+     */
+    private function resolveSlcLogger(): ?StatisticsCacheLogger
+    {
+        if ($this->resolvedLogger !== false) {
+            return $this->resolvedLogger;
+        }
+
+        try {
+            if ($this->slcLogger !== null) {
+                return $this->resolvedLogger = $this->slcLogger;
+            }
+
+            if (class_exists('Config\\Services') && method_exists(Services::class, 'doctrine')) {
+                $doctrine = Services::doctrine();
+                if (method_exists($doctrine, 'getSecondLevelCacheLogger')) {
+                    return $this->resolvedLogger = $doctrine->getSecondLevelCacheLogger();
+                }
+            }
+        } catch (Throwable) {
+            // Toolbar must never break the app.
+        }
+
+        return $this->resolvedLogger = null;
+    }
+
     public function isEmpty(): bool
     {
-        // Si hay queries, el colector no está vacío
+        // If we collected queries, the panel must render.
         if (! empty($this->queries)) {
             return false;
         }
-        // Sin queries: mostrar panel si SLC activo
+        // No queries: still render the panel if SLC stats are enabled.
         $data = $this->getData();
 
         return ! (! empty($data['slc']) && $data['slc']['enabled'] === true);
@@ -117,6 +166,10 @@ class DoctrineCollector extends BaseCollector
      */
     public function getData(): array
     {
+        if ($this->cachedData !== null) {
+            return $this->cachedData;
+        }
+
         $slc = [
             'enabled' => false,
             'hits'    => null,
@@ -124,26 +177,15 @@ class DoctrineCollector extends BaseCollector
             'puts'    => null,
         ];
 
-        // Try to read Second-Level Cache statistics via the Doctrine service
-        try {
-            $logger = $this->slcLogger;
-            if ($logger === null) {
-                $doctrine = Services::doctrine();
-                if (method_exists($doctrine, 'getSecondLevelCacheLogger')) {
-                    $logger = $doctrine->getSecondLevelCacheLogger();
-                }
-            }
-            if ($logger !== null) {
-                $slc['enabled'] = true;
-                $slc['hits']    = $logger->getHitCount();
-                $slc['misses']  = $logger->getMissCount();
-                $slc['puts']    = $logger->getPutCount();
-            }
-        } catch (Throwable $e) {
-            // Ignore SLC stats errors; keep toolbar resilient
+        $logger = $this->resolveSlcLogger();
+        if ($logger !== null) {
+            $slc['enabled'] = true;
+            $slc['hits']    = $logger->getHitCount();
+            $slc['misses']  = $logger->getMissCount();
+            $slc['puts']    = $logger->getPutCount();
         }
 
-        return [
+        return $this->cachedData = [
             'queries' => $this->getQueries(),
             'slc'     => $slc,
         ];
@@ -188,7 +230,7 @@ class DoctrineCollector extends BaseCollector
             $shortSql = preg_replace('/(select)(.+?)(from)/is', '$1 ... $3', $sql);
             $params   = htmlspecialchars(json_encode($query['params'] ?? []), ENT_QUOTES, 'UTF-8');
             $time     = isset($query['duration']) ? number_format($query['duration'], 4) : '';
-            $html .= '<tr class="{class}" title="' . htmlspecialchars($sql, ENT_QUOTES, 'UTF-8') . '" data-toggle="' . md5($sql) . '-trace">';
+            $html .= '<tr class="{class}" title="' . htmlspecialchars((string) $sql, ENT_QUOTES, 'UTF-8') . '" data-toggle="' . md5((string) $sql) . '-trace">';
             $html .= '<td class="narrow">' . $time . ' ms</td>';
             // Shorten SQL if too long (over 120 chars), show full SQL in tooltip
             $maxLen     = 120;
@@ -279,13 +321,5 @@ class DoctrineCollector extends BaseCollector
         $search = '/\b(?:' . implode('|', $highlight) . ')\b(?![^(&#039;)]*&#039;(?:(?:[^(&#039;)]*&#039;){2})*[^(&#039;)]*$)/';
 
         return preg_replace_callback($search, static fn ($matches): string => '<strong>' . str_replace(' ', '&nbsp;', $matches[0]) . '</strong>', $sql) ?? $sql;
-    }
-
-    /**
-     * Método público para testear debugToolbarDisplay
-     */
-    public function debugToolbarDisplayPublic(string $sql): string
-    {
-        return $this->debugToolbarDisplay($sql);
     }
 }

--- a/src/Debug/Toolbar/Collectors/DoctrineQueryMiddleware.php
+++ b/src/Debug/Toolbar/Collectors/DoctrineQueryMiddleware.php
@@ -16,11 +16,8 @@ use Doctrine\DBAL\ServerVersionProvider;
 
 class DoctrineQueryMiddleware implements Middleware
 {
-    protected DoctrineCollector $collector;
-
-    public function __construct(DoctrineCollector $collector)
+    public function __construct(protected DoctrineCollector $collector)
     {
-        $this->collector = $collector;
     }
 
     public function wrap(Driver $driver): Driver
@@ -28,13 +25,8 @@ class DoctrineQueryMiddleware implements Middleware
         $collector = $this->collector;
 
         return new class ($driver, $collector) implements Driver {
-            private Driver $driver;
-            private DoctrineCollector $collector;
-
-            public function __construct(Driver $driver, DoctrineCollector $collector)
+            public function __construct(private readonly Driver $driver, private readonly DoctrineCollector $collector)
             {
-                $this->driver    = $driver;
-                $this->collector = $collector;
             }
 
             public function connect(array $params): Connection
@@ -43,13 +35,8 @@ class DoctrineQueryMiddleware implements Middleware
                 $collector = $this->collector;
 
                 return new class ($conn, $collector) implements Connection {
-                    private Connection $conn;
-                    private DoctrineCollector $collector;
-
-                    public function __construct(Connection $conn, DoctrineCollector $collector)
+                    public function __construct(private readonly Connection $conn, private readonly DoctrineCollector $collector)
                     {
-                        $this->conn      = $conn;
-                        $this->collector = $collector;
                     }
 
                     public function prepare(string $sql): Statement
@@ -58,20 +45,13 @@ class DoctrineQueryMiddleware implements Middleware
                         $collector = $this->collector;
 
                         return new class ($innerStmt, $sql, $collector) implements Statement {
-                            private Statement $innerStmt;
-                            private string $sql;
-                            private DoctrineCollector $collector;
-
                             /**
                              * @var array<int|string, mixed>
                              */
                             private array $params = [];
 
-                            public function __construct(Statement $innerStmt, string $sql, DoctrineCollector $collector)
+                            public function __construct(private readonly Statement $innerStmt, private readonly string $sql, private readonly DoctrineCollector $collector)
                             {
-                                $this->innerStmt = $innerStmt;
-                                $this->sql       = $sql;
-                                $this->collector = $collector;
                             }
 
                             public function bindValue(int|string $param, mixed $value, ParameterType $type): void

--- a/src/Doctrine.php
+++ b/src/Doctrine.php
@@ -9,7 +9,7 @@ use CodeIgniter\Exceptions\ConfigException;
 use Config\Cache;
 use Config\Database;
 use Daycry\Doctrine\Config\Doctrine as DoctrineConfig;
-use Daycry\Doctrine\Debug\Toolbar\Collectors\DoctrineCollector;
+use Daycry\Doctrine\Config\Services;
 use Daycry\Doctrine\Debug\Toolbar\Collectors\DoctrineQueryMiddleware;
 use Daycry\Doctrine\Libraries\Memcached;
 use Daycry\Doctrine\Libraries\Redis;
@@ -23,6 +23,7 @@ use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
+use RuntimeException;
 use Symfony\Component\Cache\Adapter\AdapterInterface as Psr6AdapterInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\MemcachedAdapter;
@@ -158,16 +159,10 @@ class Doctrine
             $config->setSecondLevelCacheConfiguration($slcConfig);
         }
 
-        switch ($doctrineConfig->metadataConfigurationMethod) {
-            case 'xml':
-                $config->setMetadataDriverImpl(new XmlDriver($doctrineConfig->entities, XmlDriver::DEFAULT_FILE_EXTENSION, $doctrineConfig->isXsdValidationEnabled));
-                break;
-
-            case 'attribute':
-            default:
-                $config->setMetadataDriverImpl(new AttributeDriver($doctrineConfig->entities));
-                break;
-        }
+        match ($doctrineConfig->metadataConfigurationMethod) {
+            'xml'   => $config->setMetadataDriverImpl(new XmlDriver($doctrineConfig->entities, XmlDriver::DEFAULT_FILE_EXTENSION, $doctrineConfig->isXsdValidationEnabled)),
+            default => $config->setMetadataDriverImpl(new AttributeDriver($doctrineConfig->entities)),
+        };
 
         // Register custom DQL functions (beberlei/doctrineextensions + user-defined)
         foreach ($doctrineConfig->customStringFunctions as $name => $class) {
@@ -187,9 +182,8 @@ class Doctrine
             $config->addCustomStringFunction($name, $class);
         }
 
-        // INTEGRACIÓN DEL COLLECTOR Y MIDDLEWARE
-        /** @var DoctrineCollector $collector */
-        $collector  = service('doctrineCollector') ?? new DoctrineCollector();
+        // Collector and middleware integration: capture every DBAL query for the toolbar.
+        $collector  = Services::doctrineCollector();
         $dbalConfig = new \Doctrine\DBAL\Configuration();
         $middleware = new DoctrineQueryMiddleware($collector);
         $dbalConfig->setMiddlewares([$middleware]);
@@ -209,11 +203,24 @@ class Doctrine
     }
 
     /**
+     * Get the EntityManager. Throws if it has not been initialized.
+     */
+    public function getEm(): EntityManager
+    {
+        if ($this->em === null) {
+            throw new RuntimeException('EntityManager has not been initialized.');
+        }
+
+        return $this->em;
+    }
+
+    /**
      * Reopen the EntityManager with the current connection and configuration.
      */
     public function reOpen(): void
     {
-        $this->em = new EntityManager($this->em->getConnection(), $this->em->getConfiguration());
+        $em       = $this->getEm();
+        $this->em = new EntityManager($em->getConnection(), $em->getConfiguration());
         $this->registerTypeMappings(config('Doctrine'));
     }
 
@@ -222,7 +229,7 @@ class Doctrine
      */
     protected function registerTypeMappings(DoctrineConfig $doctrineConfig): void
     {
-        $platform = $this->em->getConnection()->getDatabasePlatform();
+        $platform = $this->getEm()->getConnection()->getDatabasePlatform();
 
         foreach ($doctrineConfig->customTypeMappings as $dbType => $doctrineType) {
             $platform->registerDoctrineTypeMapping($dbType, $doctrineType);
@@ -243,8 +250,8 @@ class Doctrine
         $db = (is_array($db)) ? (object) $db : $db;
         if (! empty($db->DSN)) {
             $driverMapper = ['MySQLi' => 'mysqli', 'Postgre' => 'pgsql', 'OCI8' => 'oci8', 'SQLSRV' => 'sqlsrv', 'SQLite3' => 'sqlite3'];
-            if (str_contains($db->DSN, 'SQLite')) {
-                $db->DSN = strtolower($db->DSN);
+            if (str_contains((string) $db->DSN, 'SQLite')) {
+                $db->DSN = strtolower((string) $db->DSN);
             }
             $dsnParser         = new DsnParser($driverMapper);
             $connectionOptions = $dsnParser->parse($db->DSN);
@@ -295,47 +302,6 @@ class Doctrine
                         }
                     }
             }
-        }
-
-        return $connectionOptions;
-    }
-
-    /**
-     * Convert CodeIgniter PDO config to Doctrine's connection options.
-     *
-     * @return array<string, mixed>
-     *
-     * @throws ConfigException
-     * @codeCoverageIgnore
-     */
-    protected function convertDbConfigPdo(mixed $db): array
-    {
-        if (substr($db->hostname, 0, 7) === 'sqlite:') {
-            $connectionOptions = [
-                'driver'   => 'pdo_sqlite',
-                'user'     => $db->username,
-                'password' => $db->password,
-                'path'     => preg_replace('/\Asqlite:/', '', $db->hostname),
-            ];
-        } elseif (substr($db->dsn, 0, 7) === 'sqlite:') {
-            $connectionOptions = [
-                'driver'   => 'pdo_sqlite',
-                'user'     => $db->username,
-                'password' => $db->password,
-                'path'     => preg_replace('/\Asqlite:/', '', $db->dsn),
-            ];
-        } elseif (substr($db->dsn, 0, 6) === 'mysql:') {
-            $connectionOptions = [
-                'driver'   => 'pdo_mysql',
-                'user'     => $db->username,
-                'password' => $db->password,
-                'host'     => $db->hostname,
-                'dbname'   => $db->database,
-                'charset'  => $db->charset,
-                'port'     => $db->port,
-            ];
-        } else {
-            throw new ConfigException('Your Database Configuration is not confirmed by CodeIgniter Doctrine');
         }
 
         return $connectionOptions;

--- a/src/Helpers/getFromCacheOrQuery.php
+++ b/src/Helpers/getFromCacheOrQuery.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Daycry\Doctrine\Helpers;
+
+use Daycry\Doctrine\Config\Services;
+
+/**
+ * Cache-aside helper backed by Doctrine's configured result cache.
+ *
+ * Looks up `$cacheKey` in the PSR-6 result cache pool of the Doctrine
+ * configuration. On a cache miss, executes `$queryFn`, stores the value
+ * with `$ttl` seconds expiry, and returns it.
+ *
+ * If no result cache is configured (`Config\Doctrine::$resultsCache = false`),
+ * the query is always executed and nothing is cached.
+ *
+ * @param string      $cacheKey PSR-6 compatible cache key (no reserved characters: {}()/\@:)
+ * @param int         $ttl      Lifetime in seconds; 0 means no expiration
+ * @param callable    $queryFn  Closure that returns the value to cache
+ * @param string|null $dbGroup  Optional CodeIgniter database group; null = default
+ *
+ * @return mixed The cached or freshly computed value
+ */
+function getFromCacheOrQuery(string $cacheKey, int $ttl, callable $queryFn, ?string $dbGroup = null): mixed
+{
+    $doctrine = Services::doctrine(true, $dbGroup);
+    $pool     = $doctrine->em?->getConfiguration()->getResultCache();
+
+    if ($pool === null) {
+        return $queryFn();
+    }
+
+    $item = $pool->getItem($cacheKey);
+    if ($item->isHit()) {
+        return $item->get();
+    }
+
+    $value = $queryFn();
+    $item->set($value);
+    if ($ttl > 0) {
+        $item->expiresAfter($ttl);
+    }
+    $pool->save($item);
+
+    return $value;
+}

--- a/src/Libraries/InitializesNativeClient.php
+++ b/src/Libraries/InitializesNativeClient.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Daycry\Doctrine\Libraries;
+
+use CodeIgniter\Cache\Exceptions\CacheException;
+use Throwable;
+
+/**
+ * Initializes a CodeIgniter cache handler and converts low-level connection
+ * failures into CacheException, preserving the original exception as `previous`.
+ *
+ * Used by Daycry\Doctrine\Libraries\Memcached and Daycry\Doctrine\Libraries\Redis.
+ */
+trait InitializesNativeClient
+{
+    /**
+     * @param non-empty-string $extension Extension name required for this client (e.g. 'memcached', 'redis').
+     * @param non-empty-string $driver    Human-readable driver name used in error messages.
+     */
+    protected function bootClient(string $extension, string $driver): void
+    {
+        if (! extension_loaded($extension)) {
+            throw new CacheException(sprintf(
+                '%s extension not loaded; install php-%s to enable %s cache backend.',
+                ucfirst($extension),
+                $extension,
+                $driver,
+            ));
+        }
+
+        try {
+            $this->initialize();
+        } catch (Throwable $e) {
+            throw new CacheException(sprintf('Failed to connect to %s: %s', $driver, $e->getMessage()), 0, $e);
+        }
+    }
+}

--- a/src/Libraries/Memcached.php
+++ b/src/Libraries/Memcached.php
@@ -4,39 +4,27 @@ declare(strict_types=1);
 
 namespace Daycry\Doctrine\Libraries;
 
-use CodeIgniter\Cache\Exceptions\CacheException;
 use CodeIgniter\Cache\Handlers\MemcachedHandler;
 use Config\Cache;
-use Throwable;
+use Memcached as NativeMemcached;
 
 /**
- * Memcached cache handler extension for Doctrine integration.
+ * Memcached cache handler extension that exposes the native client to Doctrine.
  */
 class Memcached extends MemcachedHandler
 {
-    /**
-     * Memcached constructor.
-     *
-     * @param Cache $config Cache configuration
-     */
+    use InitializesNativeClient;
+
     public function __construct(Cache $config)
     {
-        if (! extension_loaded('memcached')) {
-            throw new CacheException('Memcached extension not loaded; install php-memcached to enable Memcached cache backend.');
-        }
         parent::__construct($config);
-
-        try {
-            $this->initialize();
-        } catch (Throwable $e) {
-            throw new CacheException('Failed to connect to Memcached: ' . $e->getMessage(), 0, $e);
-        }
+        $this->bootClient('memcached', 'Memcached');
     }
 
     /**
-     * Get the native Memcached client instance.
+     * Native Memcached client used by Symfony Cache adapters.
      */
-    public function getInstance(): mixed
+    public function getInstance(): ?NativeMemcached
     {
         return $this->memcached;
     }

--- a/src/Libraries/Memcached.php
+++ b/src/Libraries/Memcached.php
@@ -23,9 +23,19 @@ class Memcached extends MemcachedHandler
 
     /**
      * Native Memcached client used by Symfony Cache adapters.
+     *
+     * The parent CI4 handler types `$memcached` as `Memcache|Memcached` to
+     * support either extension; only `Memcached` is supported by
+     * `Symfony\Component\Cache\Adapter\MemcachedAdapter`, so we narrow the
+     * return type here. If the underlying client is somehow a `Memcache`
+     * instance we return `null` so the caller can fail loudly with a
+     * descriptive error instead of triggering a fatal type mismatch downstream.
+     *
+     * @psalm-suppress UndefinedClass — Psalm CI runner does not load ext-memcached
      */
     public function getInstance(): ?NativeMemcached
     {
-        return $this->memcached;
+        /** @psalm-suppress UndefinedClass */
+        return $this->memcached instanceof NativeMemcached ? $this->memcached : null;
     }
 }

--- a/src/Libraries/Redis.php
+++ b/src/Libraries/Redis.php
@@ -4,39 +4,27 @@ declare(strict_types=1);
 
 namespace Daycry\Doctrine\Libraries;
 
-use CodeIgniter\Cache\Exceptions\CacheException;
 use CodeIgniter\Cache\Handlers\RedisHandler;
 use Config\Cache;
-use Throwable;
+use Redis as NativeRedis;
 
 /**
- * Redis cache handler extension for Doctrine integration.
+ * Redis cache handler extension that exposes the native client to Doctrine.
  */
 class Redis extends RedisHandler
 {
-    /**
-     * Redis constructor.
-     *
-     * @param Cache $config Cache configuration
-     */
+    use InitializesNativeClient;
+
     public function __construct(Cache $config)
     {
-        if (! extension_loaded('redis')) {
-            throw new CacheException('Redis extension not loaded; install php-redis to enable Redis cache backend.');
-        }
         parent::__construct($config);
-
-        try {
-            $this->initialize();
-        } catch (Throwable $e) {
-            throw new CacheException('Failed to connect to Redis: ' . $e->getMessage(), 0, $e);
-        }
+        $this->bootClient('redis', 'Redis');
     }
 
     /**
-     * Get the native Redis client instance.
+     * Native Redis client used by Symfony Cache adapters.
      */
-    public function getInstance(): mixed
+    public function getInstance(): ?NativeRedis
     {
         return $this->redis;
     }

--- a/src/cli-config.php
+++ b/src/cli-config.php
@@ -16,8 +16,6 @@ use Daycry\Doctrine\Doctrine;
 use Doctrine\ORM\Tools\Console\ConsoleRunner;
 use Doctrine\ORM\Tools\Console\EntityManagerProvider\SingleManagerProvider;
 
-error_reporting(E_ALL);
-
 // Path to the front controller (this file)
 define('FCPATH', __DIR__ . DIRECTORY_SEPARATOR);
 
@@ -27,6 +25,10 @@ if (getcwd() . DIRECTORY_SEPARATOR !== FCPATH) {
 }
 
 defined('ENVIRONMENT') || define('ENVIRONMENT', 'development');
+
+// Surface warnings and notices in non-production environments. Production keeps
+// CodeIgniter's own error handling (set up via Boot::bootDoctrine below).
+error_reporting(E_ALL);
 /*
  *---------------------------------------------------------------
  * BOOTSTRAP THE APPLICATION

--- a/tests/BuilderCoverageTest.php
+++ b/tests/BuilderCoverageTest.php
@@ -4,18 +4,20 @@ declare(strict_types=1);
 
 namespace Tests;
 
-use Throwable;
 use CodeIgniter\Exceptions\InvalidArgumentException;
-use Daycry\Doctrine\Doctrine;
 use Daycry\Doctrine\DataTables\Builder;
+use Daycry\Doctrine\Doctrine;
+use Doctrine\ORM\Tools\SchemaTool;
 use Tests\Support\Models\Entities\TestAttribute;
 use Tests\Support\TestCase;
-use Doctrine\ORM\Tools\SchemaTool;
+use Throwable;
 
 /**
  * Covers previously untested Builder methods:
  * - withMaxFilterValues() — exception branch and fluent-return branch
  * - getData() — with a live SQLite :memory: QueryBuilder
+ *
+ * @internal
  */
 final class BuilderCoverageTest extends TestCase
 {
@@ -113,7 +115,7 @@ final class BuilderCoverageTest extends TestCase
                         'search'     => ['value' => '', 'regex' => false],
                     ],
                 ],
-                'order'   => [['column' => 0, 'dir' => 'asc']],
+                'order' => [['column' => 0, 'dir' => 'asc']],
             ])
             ->getData();
 
@@ -169,7 +171,7 @@ final class BuilderCoverageTest extends TestCase
                         'search'     => ['value' => '', 'regex' => false],
                     ],
                 ],
-                'order'   => [['column' => 0, 'dir' => 'asc']],
+                'order' => [['column' => 0, 'dir' => 'asc']],
             ])
             ->getData();
 
@@ -231,7 +233,7 @@ final class BuilderCoverageTest extends TestCase
                         'search'     => ['value' => '', 'regex' => false],
                     ],
                 ],
-                'order'   => [['column' => 0, 'dir' => 'asc']],
+                'order' => [['column' => 0, 'dir' => 'asc']],
             ])
             ->getData();
 
@@ -289,7 +291,7 @@ final class BuilderCoverageTest extends TestCase
                         'search'     => ['value' => '', 'regex' => false],
                     ],
                 ],
-                'order'   => [['column' => 0, 'dir' => 'asc']],
+                'order' => [['column' => 0, 'dir' => 'asc']],
             ])
             ->getRecordsFiltered();
 
@@ -347,7 +349,7 @@ final class BuilderCoverageTest extends TestCase
                         'search'     => ['value' => '', 'regex' => false],
                     ],
                 ],
-                'order'   => [['column' => 0, 'dir' => 'asc']],
+                'order' => [['column' => 0, 'dir' => 'asc']],
             ])
             ->getRecordsTotal();
 
@@ -399,10 +401,10 @@ final class BuilderCoverageTest extends TestCase
                         'searchable' => true,
                         'orderable'  => true,
                         // IN: with 3 values, exceeds maxFilterValues of 2
-                        'search'     => ['value' => '[IN]a,b,c', 'regex' => false],
+                        'search' => ['value' => '[IN]a,b,c', 'regex' => false],
                     ],
                 ],
-                'order'   => [['column' => 0, 'dir' => 'asc']],
+                'order' => [['column' => 0, 'dir' => 'asc']],
             ])
             ->getData();
 
@@ -452,10 +454,10 @@ final class BuilderCoverageTest extends TestCase
                         'searchable' => true,
                         'orderable'  => true,
                         // OR: with 3 values, exceeds maxFilterValues of 2
-                        'search'     => ['value' => '[OR]x,y,z', 'regex' => false],
+                        'search' => ['value' => '[OR]x,y,z', 'regex' => false],
                     ],
                 ],
-                'order'   => [['column' => 0, 'dir' => 'asc']],
+                'order' => [['column' => 0, 'dir' => 'asc']],
             ])
             ->getData();
 

--- a/tests/Commands/DoctrinePublishTest.php
+++ b/tests/Commands/DoctrinePublishTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Commands;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use Config\Autoload;
+
+/**
+ * Happy-path coverage for `php spark doctrine:publish`.
+ *
+ * The command shells out to CLI::write/CLI::error and uses `exit()` on the
+ * error branches, which makes the failure paths intractable to assert in
+ * PHPUnit (they would terminate the test runner). This test therefore
+ * focuses on the normal path: read `cli-config.php` and `Config/Doctrine.php`
+ * from the package and write transformed copies into the host application.
+ *
+ * @internal
+ */
+final class DoctrinePublishTest extends CIUnitTestCase
+{
+    private string $cliConfigDest;
+    private string $configDest;
+    private ?string $cliConfigBackup  = null;
+    private ?string $configBackup     = null;
+    private bool $cliConfigPreExisted = false;
+    private bool $configPreExisted    = false;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $autoload = new Autoload();
+        $appPath  = $autoload->psr4[APP_NAMESPACE] ?? null;
+        $this->assertNotNull(
+            $appPath,
+            'APP_NAMESPACE must be present in Config\\Autoload::$psr4 for this test',
+        );
+
+        // Mirror the paths the command writes to.
+        $this->configDest    = rtrim($appPath, '/\\') . DIRECTORY_SEPARATOR . 'Config' . DIRECTORY_SEPARATOR . 'Doctrine.php';
+        $this->cliConfigDest = dirname(rtrim($appPath, '/\\')) . DIRECTORY_SEPARATOR . 'cli-config.php';
+
+        // Snapshot any pre-existing files so we can restore them in tearDown.
+        $this->cliConfigPreExisted = file_exists($this->cliConfigDest);
+        if ($this->cliConfigPreExisted) {
+            $this->cliConfigBackup = (string) file_get_contents($this->cliConfigDest);
+            unlink($this->cliConfigDest);
+        }
+
+        $this->configPreExisted = file_exists($this->configDest);
+        if ($this->configPreExisted) {
+            $this->configBackup = (string) file_get_contents($this->configDest);
+            unlink($this->configDest);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        // Remove anything the command created.
+        if (file_exists($this->cliConfigDest)) {
+            unlink($this->cliConfigDest);
+        }
+        if (file_exists($this->configDest)) {
+            unlink($this->configDest);
+        }
+
+        // Restore the original snapshots.
+        if ($this->cliConfigBackup !== null) {
+            file_put_contents($this->cliConfigDest, $this->cliConfigBackup);
+        }
+        if ($this->configBackup !== null) {
+            file_put_contents($this->configDest, $this->configBackup);
+        }
+
+        parent::tearDown();
+    }
+
+    public function testPublishCreatesCliConfigAndAppConfig(): void
+    {
+        // CLI::write/error go straight to STDOUT/STDERR, so we cannot capture the
+        // success banner with ob_start(); instead we verify the filesystem side
+        // effects which are what callers actually depend on.
+        command('doctrine:publish');
+
+        // Both target files must exist after publishing.
+        $this->assertFileExists($this->cliConfigDest);
+        $this->assertFileExists($this->configDest);
+
+        // The CLI config is copied verbatim from the package.
+        $this->assertStringContainsString('ConsoleRunner::run', file_get_contents($this->cliConfigDest));
+
+        // The Config\Doctrine class is rewritten with the host namespace and parent.
+        $configContent = file_get_contents($this->configDest);
+        $this->assertStringContainsString('namespace Config', $configContent);
+        $this->assertStringContainsString('extends \\Daycry\\Doctrine\\Config\\Doctrine', $configContent);
+        $this->assertStringNotContainsString('namespace Daycry\\Doctrine\\Config', $configContent);
+        $this->assertStringNotContainsString('extends BaseConfig', $configContent);
+    }
+}

--- a/tests/Commands/DoctrinePublishTest.php
+++ b/tests/Commands/DoctrinePublishTest.php
@@ -89,13 +89,13 @@ final class DoctrinePublishTest extends CIUnitTestCase
         $this->assertFileExists($this->configDest);
 
         // The CLI config is copied verbatim from the package.
-        $this->assertStringContainsString('ConsoleRunner::run', file_get_contents($this->cliConfigDest));
+        $this->assertStringContainsString('ConsoleRunner::run', (string) file_get_contents($this->cliConfigDest));
 
         // The Config\Doctrine class is rewritten with the host namespace and parent.
         $configContent = file_get_contents($this->configDest);
-        $this->assertStringContainsString('namespace Config', $configContent);
-        $this->assertStringContainsString('extends \\Daycry\\Doctrine\\Config\\Doctrine', $configContent);
-        $this->assertStringNotContainsString('namespace Daycry\\Doctrine\\Config', $configContent);
-        $this->assertStringNotContainsString('extends BaseConfig', $configContent);
+        $this->assertStringContainsString('namespace Config', (string) $configContent);
+        $this->assertStringContainsString('extends \\Daycry\\Doctrine\\Config\\Doctrine', (string) $configContent);
+        $this->assertStringNotContainsString('namespace Daycry\\Doctrine\\Config', (string) $configContent);
+        $this->assertStringNotContainsString('extends BaseConfig', (string) $configContent);
     }
 }

--- a/tests/Connection/MysqlTest.php
+++ b/tests/Connection/MysqlTest.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Connection;
 
-use Tests\Support\TestCase;
-use Config\Database;
 use Daycry\Doctrine\Doctrine;
 use Doctrine\ORM\EntityManager;
+use Tests\Support\TestCase;
 
+/**
+ * @internal
+ */
 final class MysqlTest extends TestCase
 {
     public function testDSNMysql()
@@ -32,5 +34,4 @@ final class MysqlTest extends TestCase
         $this->assertInstanceOf(EntityManager::class, $doctrine->em);
         $this->assertSame('doctrine_tests', $doctrine->em->getConnection()->getDatabase());
     }
-
 }

--- a/tests/Connection/SQLite3Test.php
+++ b/tests/Connection/SQLite3Test.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Connection;
 
-use Tests\Support\TestCase;
-use Config\Database;
 use Daycry\Doctrine\Doctrine;
 use Doctrine\ORM\EntityManager;
+use Tests\Support\TestCase;
 
+/**
+ * @internal
+ */
 final class SQLite3Test extends TestCase
 {
     public function testDSNSQLite3()
@@ -50,5 +52,4 @@ final class SQLite3Test extends TestCase
         $this->assertInstanceOf(Doctrine::class, $doctrine);
         $this->assertInstanceOf(EntityManager::class, $doctrine->em);
     }
-
 }

--- a/tests/DataTableTest.php
+++ b/tests/DataTableTest.php
@@ -6,12 +6,15 @@ namespace Tests;
 
 use CodeIgniter\Test\DatabaseTestTrait;
 use CodeIgniter\Test\FeatureTestTrait;
-use Daycry\Doctrine\Doctrine;
 use Daycry\Doctrine\DataTables\Builder;
+use Daycry\Doctrine\Doctrine;
+use Tests\Support\Database\Seeds\TestSeeder;
 use Tests\Support\Models\Entities\TestAttribute;
 use Tests\Support\TestCase;
-use Tests\Support\Database\Seeds\TestSeeder;
 
+/**
+ * @internal
+ */
 final class DataTableTest extends TestCase
 {
     use DatabaseTestTrait;
@@ -28,9 +31,9 @@ final class DataTableTest extends TestCase
         $datatables = (new Builder())
             ->withColumnAliases(
                 [
-                    'id' => 't.id',
-                    'name' => 't.name'
-                ]
+                    'id'   => 't.id',
+                    'name' => 't.name',
+                ],
             )
             ->withIndexColumn('qlu.id')
             ->setUseOutputWalkers(false)
@@ -39,32 +42,32 @@ final class DataTableTest extends TestCase
             ->withQueryBuilder(
                 $doctrine->em->createQueryBuilder()
                     ->select('t.id, t.name')
-                    ->from(TestAttribute::class, 't')
+                    ->from(TestAttribute::class, 't'),
             )
             ->withRequestParams(
                 [
-                    'draw' => 1,
-                    'start' => 0,
-                    'length' => 10,
-                    'search' => ['value' => 'am', 'regex' => false ],
+                    'draw'    => 1,
+                    'start'   => 0,
+                    'length'  => 10,
+                    'search'  => ['value' => 'am', 'regex' => false],
                     'columns' => [
                         [
-                            'data' => 'id',
-                            'name' => 'id',
+                            'data'       => 'id',
+                            'name'       => 'id',
                             'searchable' => true,
-                            'orderable' => true,
-                            'search' => ['value' => '', 'regex' => false]
+                            'orderable'  => true,
+                            'search'     => ['value' => '', 'regex' => false],
                         ],
                         [
-                            'data' => 'name',
-                            'name' => 'name',
+                            'data'       => 'name',
+                            'name'       => 'name',
                             'searchable' => true,
-                            'orderable' => true,
-                            'search' => ['value' => '', 'regex' => false]
-                        ]
+                            'orderable'  => true,
+                            'search'     => ['value' => '', 'regex' => false],
+                        ],
                     ],
-                    'order' => [ [ 'column' => 0, 'dir' => 'asc'] ]
-                ]
+                    'order' => [['column' => 0, 'dir' => 'asc']],
+                ],
             );
 
         $response = $datatables->getResponse();
@@ -72,7 +75,6 @@ final class DataTableTest extends TestCase
         $this->assertArrayHasKey('data', $response);
         $this->assertCount(2, $response['data']);
     }
-
 
     public function testDataTableSearchColumn()
     {
@@ -83,9 +85,9 @@ final class DataTableTest extends TestCase
         $datatables = (new Builder())
             ->withColumnAliases(
                 [
-                    'id' => 't.id',
-                    'name' => 't.name'
-                ]
+                    'id'   => 't.id',
+                    'name' => 't.name',
+                ],
             )
             ->withIndexColumn('qlu.id')
             ->setUseOutputWalkers(false)
@@ -94,32 +96,32 @@ final class DataTableTest extends TestCase
             ->withQueryBuilder(
                 $doctrine->em->createQueryBuilder()
                     ->select('t.id, t.name')
-                    ->from(TestAttribute::class, 't')
+                    ->from(TestAttribute::class, 't'),
             )
             ->withRequestParams(
                 [
-                    'draw' => 1,
-                    'start' => 0,
-                    'length' => 10,
-                    'search' => ['value' => '', 'regex' => true ],
+                    'draw'    => 1,
+                    'start'   => 0,
+                    'length'  => 10,
+                    'search'  => ['value' => '', 'regex' => true],
                     'columns' => [
                         [
-                            'data' => 'id',
-                            'name' => 'id',
+                            'data'       => 'id',
+                            'name'       => 'id',
                             'searchable' => true,
-                            'orderable' => true,
-                            'search' => ['value' => '', 'regex' => false]
+                            'orderable'  => true,
+                            'search'     => ['value' => '', 'regex' => false],
                         ],
                         [
-                            'data' => 'name',
-                            'name' => 'name',
+                            'data'       => 'name',
+                            'name'       => 'name',
                             'searchable' => true,
-                            'orderable' => true,
-                            'search' => ['value' => 'name1', 'regex' => true]
-                        ]
+                            'orderable'  => true,
+                            'search'     => ['value' => 'name1', 'regex' => true],
+                        ],
                     ],
-                    'order' => [ [ 'column' => 0, 'dir' => 'asc'] ]
-                ]
+                    'order' => [['column' => 0, 'dir' => 'asc']],
+                ],
             );
 
         $response = $datatables->getResponse();
@@ -137,9 +139,9 @@ final class DataTableTest extends TestCase
         $datatables = (new Builder())
             ->withColumnAliases(
                 [
-                    'id' => 't.id',
-                    'name' => 't.name'
-                ]
+                    'id'   => 't.id',
+                    'name' => 't.name',
+                ],
             )
             ->withIndexColumn('qlu.id')
             ->setUseOutputWalkers(false)
@@ -148,32 +150,32 @@ final class DataTableTest extends TestCase
             ->withQueryBuilder(
                 $doctrine->em->createQueryBuilder()
                     ->select('t.id, t.name')
-                    ->from(TestAttribute::class, 't')
+                    ->from(TestAttribute::class, 't'),
             )
             ->withRequestParams(
                 [
-                    'draw' => 1,
-                    'start' => 0,
-                    'length' => 10,
-                    'search' => ['value' => '', 'regex' => true ],
+                    'draw'    => 1,
+                    'start'   => 0,
+                    'length'  => 10,
+                    'search'  => ['value' => '', 'regex' => true],
                     'columns' => [
                         [
-                            'data' => 'id',
-                            'name' => 'id',
+                            'data'       => 'id',
+                            'name'       => 'id',
                             'searchable' => true,
-                            'orderable' => true,
-                            'search' => ['value' => '', 'regex' => false]
+                            'orderable'  => true,
+                            'search'     => ['value' => '', 'regex' => false],
                         ],
                         [
-                            'data' => 'name',
-                            'name' => 'name',
+                            'data'       => 'name',
+                            'name'       => 'name',
                             'searchable' => true,
-                            'orderable' => true,
-                            'search' => ['value' => '[%%]am', 'regex' => false]
-                        ]
+                            'orderable'  => true,
+                            'search'     => ['value' => '[%%]am', 'regex' => false],
+                        ],
                     ],
-                    'order' => [ [ 'column' => 0, 'dir' => 'asc'] ]
-                ]
+                    'order' => [['column' => 0, 'dir' => 'asc']],
+                ],
             );
 
         $response = $datatables->getResponse();
@@ -191,9 +193,9 @@ final class DataTableTest extends TestCase
         $datatables = (new Builder())
             ->withColumnAliases(
                 [
-                    'id' => 't.id',
-                    'name' => 't.name'
-                ]
+                    'id'   => 't.id',
+                    'name' => 't.name',
+                ],
             )
             ->withIndexColumn('qlu.id')
             ->setUseOutputWalkers(false)
@@ -202,33 +204,33 @@ final class DataTableTest extends TestCase
             ->withQueryBuilder(
                 $doctrine->em->createQueryBuilder()
                     ->select('t.id, t.name')
-                    ->from(TestAttribute::class, 't')
+                    ->from(TestAttribute::class, 't'),
             )
             ->withRequestParams(
                 [
-                    'draw' => 1,
-                    'start' => 0,
-                    'length' => 10,
-                    'search' => ['value' => '', 'regex' => true ],
+                    'draw'    => 1,
+                    'start'   => 0,
+                    'length'  => 10,
+                    'search'  => ['value' => '', 'regex' => true],
                     'columns' => [
                         [
-                            'data' => 'id',
-                            'name' => 'id',
+                            'data'       => 'id',
+                            'name'       => 'id',
                             'searchable' => true,
-                            'orderable' => true,
-                            'search' => ['value' => '', 'regex' => false]
+                            'orderable'  => true,
+                            'search'     => ['value' => '', 'regex' => false],
                         ],
                         [
-                            'data' => 'name',
-                            'name' => 'name',
+                            'data'       => 'name',
+                            'name'       => 'name',
                             'searchable' => true,
-                            'orderable' => true,
+                            'orderable'  => true,
                             // Unsupported operator should fallback to LIKE
-                            'search' => ['value' => '[XYZ]am', 'regex' => false]
-                        ]
+                            'search' => ['value' => '[XYZ]am', 'regex' => false],
+                        ],
                     ],
-                    'order' => [ [ 'column' => 0, 'dir' => 'asc'] ]
-                ]
+                    'order' => [['column' => 0, 'dir' => 'asc']],
+                ],
             );
 
         $response = $datatables->getResponse();
@@ -247,8 +249,8 @@ final class DataTableTest extends TestCase
         // [LIKE] synonym
         $datatablesLike = (new Builder())
             ->withColumnAliases([
-                'id' => 't.id',
-                'name' => 't.name'
+                'id'   => 't.id',
+                'name' => 't.name',
             ])
             ->withIndexColumn('qlu.id')
             ->setUseOutputWalkers(false)
@@ -257,30 +259,30 @@ final class DataTableTest extends TestCase
             ->withQueryBuilder(
                 $doctrine->em->createQueryBuilder()
                     ->select('t.id, t.name')
-                    ->from(TestAttribute::class, 't')
+                    ->from(TestAttribute::class, 't'),
             )
             ->withRequestParams([
-                'draw' => 1,
-                'start' => 0,
-                'length' => 10,
-                'search' => ['value' => '', 'regex' => true],
+                'draw'    => 1,
+                'start'   => 0,
+                'length'  => 10,
+                'search'  => ['value' => '', 'regex' => true],
                 'columns' => [
                     [
-                        'data' => 'id',
-                        'name' => 'id',
+                        'data'       => 'id',
+                        'name'       => 'id',
                         'searchable' => true,
-                        'orderable' => true,
-                        'search' => ['value' => '', 'regex' => false]
+                        'orderable'  => true,
+                        'search'     => ['value' => '', 'regex' => false],
                     ],
                     [
-                        'data' => 'name',
-                        'name' => 'name',
+                        'data'       => 'name',
+                        'name'       => 'name',
                         'searchable' => true,
-                        'orderable' => true,
-                        'search' => ['value' => '[LIKE]am', 'regex' => false]
-                    ]
+                        'orderable'  => true,
+                        'search'     => ['value' => '[LIKE]am', 'regex' => false],
+                    ],
                 ],
-                'order' => [ [ 'column' => 0, 'dir' => 'asc'] ]
+                'order' => [['column' => 0, 'dir' => 'asc']],
             ]);
 
         $respLike = $datatablesLike->getResponse();
@@ -288,8 +290,8 @@ final class DataTableTest extends TestCase
         // [%%] synonym
         $datatablesDoublePct = (new Builder())
             ->withColumnAliases([
-                'id' => 't.id',
-                'name' => 't.name'
+                'id'   => 't.id',
+                'name' => 't.name',
             ])
             ->withIndexColumn('qlu.id')
             ->setUseOutputWalkers(false)
@@ -298,30 +300,30 @@ final class DataTableTest extends TestCase
             ->withQueryBuilder(
                 $doctrine->em->createQueryBuilder()
                     ->select('t.id, t.name')
-                    ->from(TestAttribute::class, 't')
+                    ->from(TestAttribute::class, 't'),
             )
             ->withRequestParams([
-                'draw' => 1,
-                'start' => 0,
-                'length' => 10,
-                'search' => ['value' => '', 'regex' => true],
+                'draw'    => 1,
+                'start'   => 0,
+                'length'  => 10,
+                'search'  => ['value' => '', 'regex' => true],
                 'columns' => [
                     [
-                        'data' => 'id',
-                        'name' => 'id',
+                        'data'       => 'id',
+                        'name'       => 'id',
                         'searchable' => true,
-                        'orderable' => true,
-                        'search' => ['value' => '', 'regex' => false]
+                        'orderable'  => true,
+                        'search'     => ['value' => '', 'regex' => false],
                     ],
                     [
-                        'data' => 'name',
-                        'name' => 'name',
+                        'data'       => 'name',
+                        'name'       => 'name',
                         'searchable' => true,
-                        'orderable' => true,
-                        'search' => ['value' => '[%%]am', 'regex' => false]
-                    ]
+                        'orderable'  => true,
+                        'search'     => ['value' => '[%%]am', 'regex' => false],
+                    ],
                 ],
-                'order' => [ [ 'column' => 0, 'dir' => 'asc'] ]
+                'order' => [['column' => 0, 'dir' => 'asc']],
             ]);
 
         $respDoublePct = $datatablesDoublePct->getResponse();
@@ -341,8 +343,8 @@ final class DataTableTest extends TestCase
         // Global search 'am' should apply only to valid fields; numeric 'data' should be ignored
         $datatables = (new Builder())
             ->withColumnAliases([
-                'id' => 't.id',
-                'name' => 't.name'
+                'id'   => 't.id',
+                'name' => 't.name',
             ])
             ->withIndexColumn('qlu.id')
             ->setUseOutputWalkers(false)
@@ -352,31 +354,31 @@ final class DataTableTest extends TestCase
             ->withQueryBuilder(
                 $doctrine->em->createQueryBuilder()
                     ->select('t.id, t.name')
-                    ->from(TestAttribute::class, 't')
+                    ->from(TestAttribute::class, 't'),
             )
             ->withRequestParams([
-                'draw' => 1,
-                'start' => 0,
-                'length' => 10,
-                'search' => ['value' => 'am', 'regex' => false],
+                'draw'    => 1,
+                'start'   => 0,
+                'length'  => 10,
+                'search'  => ['value' => 'am', 'regex' => false],
                 'columns' => [
                     [
                         // intentionally numeric to simulate bad client config
-                        'data' => '0',
-                        'name' => 'id',
+                        'data'       => '0',
+                        'name'       => 'id',
                         'searchable' => true,
-                        'orderable' => true,
-                        'search' => ['value' => '', 'regex' => false]
+                        'orderable'  => true,
+                        'search'     => ['value' => '', 'regex' => false],
                     ],
                     [
-                        'data' => 'name',
-                        'name' => 'name',
+                        'data'       => 'name',
+                        'name'       => 'name',
                         'searchable' => true,
-                        'orderable' => true,
-                        'search' => ['value' => '', 'regex' => false]
-                    ]
+                        'orderable'  => true,
+                        'search'     => ['value' => '', 'regex' => false],
+                    ],
                 ],
-                'order' => [ [ 'column' => 0, 'dir' => 'asc'] ]
+                'order' => [['column' => 0, 'dir' => 'asc']],
             ]);
 
         $response = $datatables->getResponse();
@@ -396,8 +398,8 @@ final class DataTableTest extends TestCase
         // OR operator with case-insensitive LIKE
         $builderOr = (new Builder())
             ->withColumnAliases([
-                'id' => 't.id',
-                'name' => 't.name'
+                'id'   => 't.id',
+                'name' => 't.name',
             ])
             ->withIndexColumn('qlu.id')
             ->setUseOutputWalkers(false)
@@ -406,31 +408,31 @@ final class DataTableTest extends TestCase
             ->withQueryBuilder(
                 $doctrine->em->createQueryBuilder()
                     ->select('t.id, t.name')
-                    ->from(TestAttribute::class, 't')
+                    ->from(TestAttribute::class, 't'),
             )
             ->withRequestParams([
-                'draw' => 1,
-                'start' => 0,
-                'length' => 10,
-                'search' => ['value' => '', 'regex' => true],
+                'draw'    => 1,
+                'start'   => 0,
+                'length'  => 10,
+                'search'  => ['value' => '', 'regex' => true],
                 'columns' => [
                     [
-                        'data' => 'id',
-                        'name' => 'id',
+                        'data'       => 'id',
+                        'name'       => 'id',
                         'searchable' => true,
-                        'orderable' => true,
-                        'search' => ['value' => '', 'regex' => false]
+                        'orderable'  => true,
+                        'search'     => ['value' => '', 'regex' => false],
                     ],
                     [
-                        'data' => 'name',
-                        'name' => 'name',
+                        'data'       => 'name',
+                        'name'       => 'name',
                         'searchable' => true,
-                        'orderable' => true,
+                        'orderable'  => true,
                         // OR no aplica lower() en Builder, usar valores existentes en minúscula
-                        'search' => ['value' => '[OR]name1,name2', 'regex' => false]
-                    ]
+                        'search' => ['value' => '[OR]name1,name2', 'regex' => false],
+                    ],
                 ],
-                'order' => [ [ 'column' => 0, 'dir' => 'asc'] ]
+                'order' => [['column' => 0, 'dir' => 'asc']],
             ]);
 
         $respOr = $builderOr->getResponse();
@@ -440,8 +442,8 @@ final class DataTableTest extends TestCase
         // IN operator should be case-insensitive irrelevant (exact match on ids)
         $builderIn = (new Builder())
             ->withColumnAliases([
-                'id' => 't.id',
-                'name' => 't.name'
+                'id'   => 't.id',
+                'name' => 't.name',
             ])
             ->withIndexColumn('qlu.id')
             ->setUseOutputWalkers(false)
@@ -450,30 +452,30 @@ final class DataTableTest extends TestCase
             ->withQueryBuilder(
                 $doctrine->em->createQueryBuilder()
                     ->select('t.id, t.name')
-                    ->from(TestAttribute::class, 't')
+                    ->from(TestAttribute::class, 't'),
             )
             ->withRequestParams([
-                'draw' => 1,
-                'start' => 0,
-                'length' => 10,
-                'search' => ['value' => '', 'regex' => true],
+                'draw'    => 1,
+                'start'   => 0,
+                'length'  => 10,
+                'search'  => ['value' => '', 'regex' => true],
                 'columns' => [
                     [
-                        'data' => 'id',
-                        'name' => 'id',
+                        'data'       => 'id',
+                        'name'       => 'id',
                         'searchable' => true,
-                        'orderable' => true,
-                        'search' => ['value' => '[IN]1,2', 'regex' => false]
+                        'orderable'  => true,
+                        'search'     => ['value' => '[IN]1,2', 'regex' => false],
                     ],
                     [
-                        'data' => 'name',
-                        'name' => 'name',
+                        'data'       => 'name',
+                        'name'       => 'name',
                         'searchable' => true,
-                        'orderable' => true,
-                        'search' => ['value' => '', 'regex' => false]
-                    ]
+                        'orderable'  => true,
+                        'search'     => ['value' => '', 'regex' => false],
+                    ],
                 ],
-                'order' => [ [ 'column' => 0, 'dir' => 'asc'] ]
+                'order' => [['column' => 0, 'dir' => 'asc']],
             ]);
 
         $respIn = $builderIn->getResponse();
@@ -483,8 +485,8 @@ final class DataTableTest extends TestCase
         // BETWEEN (><) on ids
         $builderBetween = (new Builder())
             ->withColumnAliases([
-                'id' => 't.id',
-                'name' => 't.name'
+                'id'   => 't.id',
+                'name' => 't.name',
             ])
             ->withIndexColumn('qlu.id')
             ->setUseOutputWalkers(false)
@@ -493,30 +495,30 @@ final class DataTableTest extends TestCase
             ->withQueryBuilder(
                 $doctrine->em->createQueryBuilder()
                     ->select('t.id, t.name')
-                    ->from(TestAttribute::class, 't')
+                    ->from(TestAttribute::class, 't'),
             )
             ->withRequestParams([
-                'draw' => 1,
-                'start' => 0,
-                'length' => 10,
-                'search' => ['value' => '', 'regex' => true],
+                'draw'    => 1,
+                'start'   => 0,
+                'length'  => 10,
+                'search'  => ['value' => '', 'regex' => true],
                 'columns' => [
                     [
-                        'data' => 'id',
-                        'name' => 'id',
+                        'data'       => 'id',
+                        'name'       => 'id',
                         'searchable' => true,
-                        'orderable' => true,
-                        'search' => ['value' => '[><]1,2', 'regex' => false]
+                        'orderable'  => true,
+                        'search'     => ['value' => '[><]1,2', 'regex' => false],
                     ],
                     [
-                        'data' => 'name',
-                        'name' => 'name',
+                        'data'       => 'name',
+                        'name'       => 'name',
                         'searchable' => true,
-                        'orderable' => true,
-                        'search' => ['value' => '', 'regex' => false]
-                    ]
+                        'orderable'  => true,
+                        'search'     => ['value' => '', 'regex' => false],
+                    ],
                 ],
-                'order' => [ [ 'column' => 0, 'dir' => 'asc'] ]
+                'order' => [['column' => 0, 'dir' => 'asc']],
             ]);
 
         $respBetween = $builderBetween->getResponse();
@@ -533,8 +535,8 @@ final class DataTableTest extends TestCase
         // Combina búsqueda global '%am%' (sobre 'name') y filtro por columna 'id' con IN
         $datatables = (new Builder())
             ->withColumnAliases([
-                'id' => 't.id',
-                'name' => 't.name'
+                'id'   => 't.id',
+                'name' => 't.name',
             ])
             ->withIndexColumn('qlu.id')
             ->setUseOutputWalkers(false)
@@ -544,30 +546,30 @@ final class DataTableTest extends TestCase
             ->withQueryBuilder(
                 $doctrine->em->createQueryBuilder()
                     ->select('t.id, t.name')
-                    ->from(TestAttribute::class, 't')
+                    ->from(TestAttribute::class, 't'),
             )
             ->withRequestParams([
-                'draw' => 1,
-                'start' => 0,
-                'length' => 10,
-                'search' => ['value' => 'am', 'regex' => false],
+                'draw'    => 1,
+                'start'   => 0,
+                'length'  => 10,
+                'search'  => ['value' => 'am', 'regex' => false],
                 'columns' => [
                     [
-                        'data' => 'id',
-                        'name' => 'id',
+                        'data'       => 'id',
+                        'name'       => 'id',
                         'searchable' => true,
-                        'orderable' => true,
-                        'search' => ['value' => '[IN]1,2', 'regex' => false]
+                        'orderable'  => true,
+                        'search'     => ['value' => '[IN]1,2', 'regex' => false],
                     ],
                     [
-                        'data' => 'name',
-                        'name' => 'name',
+                        'data'       => 'name',
+                        'name'       => 'name',
                         'searchable' => true,
-                        'orderable' => true,
-                        'search' => ['value' => '', 'regex' => false]
-                    ]
+                        'orderable'  => true,
+                        'search'     => ['value' => '', 'regex' => false],
+                    ],
                 ],
-                'order' => [ [ 'column' => 0, 'dir' => 'asc'] ]
+                'order' => [['column' => 0, 'dir' => 'asc']],
             ]);
 
         $response = $datatables->getResponse();
@@ -586,9 +588,9 @@ final class DataTableTest extends TestCase
         $datatables = (new Builder())
             ->withColumnAliases(
                 [
-                    'id' => 't.id',
-                    'name' => 't.name'
-                ]
+                    'id'   => 't.id',
+                    'name' => 't.name',
+                ],
             )
             ->withIndexColumn('qlu.id')
             ->setUseOutputWalkers(false)
@@ -597,32 +599,32 @@ final class DataTableTest extends TestCase
             ->withQueryBuilder(
                 $doctrine->em->createQueryBuilder()
                     ->select('t.id, t.name')
-                    ->from(TestAttribute::class, 't')
+                    ->from(TestAttribute::class, 't'),
             )
             ->withRequestParams(
                 [
-                    'draw' => 1,
-                    'start' => 0,
-                    'length' => 10,
-                    'search' => ['value' => '', 'regex' => true ],
+                    'draw'    => 1,
+                    'start'   => 0,
+                    'length'  => 10,
+                    'search'  => ['value' => '', 'regex' => true],
                     'columns' => [
                         [
-                            'data' => 'id',
-                            'name' => 'id',
+                            'data'       => 'id',
+                            'name'       => 'id',
                             'searchable' => true,
-                            'orderable' => true,
-                            'search' => ['value' => '', 'regex' => false]
+                            'orderable'  => true,
+                            'search'     => ['value' => '', 'regex' => false],
                         ],
                         [
-                            'data' => 'name',
-                            'name' => 'name',
+                            'data'       => 'name',
+                            'name'       => 'name',
                             'searchable' => true,
-                            'orderable' => true,
-                            'search' => ['value' => '[!=]name1', 'regex' => false]
-                        ]
+                            'orderable'  => true,
+                            'search'     => ['value' => '[!=]name1', 'regex' => false],
+                        ],
                     ],
-                    'order' => [ [ 'column' => 0, 'dir' => 'asc'] ]
-                ]
+                    'order' => [['column' => 0, 'dir' => 'asc']],
+                ],
             );
 
         $response = $datatables->getResponse();
@@ -640,9 +642,9 @@ final class DataTableTest extends TestCase
         $datatables = (new Builder())
             ->withColumnAliases(
                 [
-                    'id' => 't.id',
-                    'name' => 't.name'
-                ]
+                    'id'   => 't.id',
+                    'name' => 't.name',
+                ],
             )
             ->withIndexColumn('qlu.id')
             ->setUseOutputWalkers(false)
@@ -651,32 +653,32 @@ final class DataTableTest extends TestCase
             ->withQueryBuilder(
                 $doctrine->em->createQueryBuilder()
                     ->select('t.id, t.name')
-                    ->from(TestAttribute::class, 't')
+                    ->from(TestAttribute::class, 't'),
             )
             ->withRequestParams(
                 [
-                    'draw' => 1,
-                    'start' => 0,
-                    'length' => 10,
-                    'search' => ['value' => '', 'regex' => true ],
+                    'draw'    => 1,
+                    'start'   => 0,
+                    'length'  => 10,
+                    'search'  => ['value' => '', 'regex' => true],
                     'columns' => [
                         [
-                            'data' => 'id',
-                            'name' => 'id',
+                            'data'       => 'id',
+                            'name'       => 'id',
                             'searchable' => true,
-                            'orderable' => true,
-                            'search' => ['value' => '[<]2', 'regex' => false]
+                            'orderable'  => true,
+                            'search'     => ['value' => '[<]2', 'regex' => false],
                         ],
                         [
-                            'data' => 'name',
-                            'name' => 'name',
+                            'data'       => 'name',
+                            'name'       => 'name',
                             'searchable' => true,
-                            'orderable' => true,
-                            'search' => ['value' => '', 'regex' => false]
-                        ]
+                            'orderable'  => true,
+                            'search'     => ['value' => '', 'regex' => false],
+                        ],
                     ],
-                    'order' => [ [ 'column' => 0, 'dir' => 'asc'] ]
-                ]
+                    'order' => [['column' => 0, 'dir' => 'asc']],
+                ],
             );
 
         $response = $datatables->getResponse();
@@ -694,9 +696,9 @@ final class DataTableTest extends TestCase
         $datatables = (new Builder())
             ->withColumnAliases(
                 [
-                    'id' => 't.id',
-                    'name' => 't.name'
-                ]
+                    'id'   => 't.id',
+                    'name' => 't.name',
+                ],
             )
             ->withIndexColumn('qlu.id')
             ->setUseOutputWalkers(false)
@@ -705,32 +707,32 @@ final class DataTableTest extends TestCase
             ->withQueryBuilder(
                 $doctrine->em->createQueryBuilder()
                     ->select('t.id, t.name')
-                    ->from(TestAttribute::class, 't')
+                    ->from(TestAttribute::class, 't'),
             )
             ->withRequestParams(
                 [
-                    'draw' => 1,
-                    'start' => 0,
-                    'length' => 10,
-                    'search' => ['value' => '', 'regex' => true ],
+                    'draw'    => 1,
+                    'start'   => 0,
+                    'length'  => 10,
+                    'search'  => ['value' => '', 'regex' => true],
                     'columns' => [
                         [
-                            'data' => 'id',
-                            'name' => 'id',
+                            'data'       => 'id',
+                            'name'       => 'id',
                             'searchable' => true,
-                            'orderable' => true,
-                            'search' => ['value' => '[>]1', 'regex' => false]
+                            'orderable'  => true,
+                            'search'     => ['value' => '[>]1', 'regex' => false],
                         ],
                         [
-                            'data' => 'name',
-                            'name' => 'name',
+                            'data'       => 'name',
+                            'name'       => 'name',
                             'searchable' => true,
-                            'orderable' => true,
-                            'search' => ['value' => '', 'regex' => false]
-                        ]
+                            'orderable'  => true,
+                            'search'     => ['value' => '', 'regex' => false],
+                        ],
                     ],
-                    'order' => [ [ 'column' => 0, 'dir' => 'asc'] ]
-                ]
+                    'order' => [['column' => 0, 'dir' => 'asc']],
+                ],
             );
 
         $response = $datatables->getResponse();
@@ -748,9 +750,9 @@ final class DataTableTest extends TestCase
         $datatables = (new Builder())
             ->withColumnAliases(
                 [
-                    'id' => 't.id',
-                    'name' => 't.name'
-                ]
+                    'id'   => 't.id',
+                    'name' => 't.name',
+                ],
             )
             ->withIndexColumn('qlu.id')
             ->setUseOutputWalkers(false)
@@ -759,32 +761,32 @@ final class DataTableTest extends TestCase
             ->withQueryBuilder(
                 $doctrine->em->createQueryBuilder()
                     ->select('t.id, t.name')
-                    ->from(TestAttribute::class, 't')
+                    ->from(TestAttribute::class, 't'),
             )
             ->withRequestParams(
                 [
-                    'draw' => 1,
-                    'start' => 0,
-                    'length' => 10,
-                    'search' => ['value' => '', 'regex' => true ],
+                    'draw'    => 1,
+                    'start'   => 0,
+                    'length'  => 10,
+                    'search'  => ['value' => '', 'regex' => true],
                     'columns' => [
                         [
-                            'data' => 'id',
-                            'name' => 'id',
+                            'data'       => 'id',
+                            'name'       => 'id',
                             'searchable' => true,
-                            'orderable' => true,
-                            'search' => ['value' => '[IN]2,3', 'regex' => false]
+                            'orderable'  => true,
+                            'search'     => ['value' => '[IN]2,3', 'regex' => false],
                         ],
                         [
-                            'data' => 'name',
-                            'name' => 'name',
+                            'data'       => 'name',
+                            'name'       => 'name',
                             'searchable' => true,
-                            'orderable' => true,
-                            'search' => ['value' => '', 'regex' => false]
-                        ]
+                            'orderable'  => true,
+                            'search'     => ['value' => '', 'regex' => false],
+                        ],
                     ],
-                    'order' => [ [ 'column' => 0, 'dir' => 'asc'] ]
-                ]
+                    'order' => [['column' => 0, 'dir' => 'asc']],
+                ],
             );
 
         $response = $datatables->getResponse();
@@ -802,9 +804,9 @@ final class DataTableTest extends TestCase
         $datatables = (new Builder())
             ->withColumnAliases(
                 [
-                    'id' => 't.id',
-                    'name' => 't.name'
-                ]
+                    'id'   => 't.id',
+                    'name' => 't.name',
+                ],
             )
             ->withIndexColumn('qlu.id')
             ->setUseOutputWalkers(false)
@@ -813,32 +815,32 @@ final class DataTableTest extends TestCase
             ->withQueryBuilder(
                 $doctrine->em->createQueryBuilder()
                     ->select('t.id, t.name')
-                    ->from(TestAttribute::class, 't')
+                    ->from(TestAttribute::class, 't'),
             )
             ->withRequestParams(
                 [
-                    'draw' => 1,
-                    'start' => 0,
-                    'length' => 10,
-                    'search' => ['value' => '', 'regex' => true ],
+                    'draw'    => 1,
+                    'start'   => 0,
+                    'length'  => 10,
+                    'search'  => ['value' => '', 'regex' => true],
                     'columns' => [
                         [
-                            'data' => 'id',
-                            'name' => 'id',
+                            'data'       => 'id',
+                            'name'       => 'id',
                             'searchable' => true,
-                            'orderable' => true,
-                            'search' => ['value' => '[OR]1,3', 'regex' => false]
+                            'orderable'  => true,
+                            'search'     => ['value' => '[OR]1,3', 'regex' => false],
                         ],
                         [
-                            'data' => 'name',
-                            'name' => 'name',
+                            'data'       => 'name',
+                            'name'       => 'name',
                             'searchable' => true,
-                            'orderable' => true,
-                            'search' => ['value' => '', 'regex' => false]
-                        ]
+                            'orderable'  => true,
+                            'search'     => ['value' => '', 'regex' => false],
+                        ],
                     ],
-                    'order' => [ [ 'column' => 0, 'dir' => 'asc'] ]
-                ]
+                    'order' => [['column' => 0, 'dir' => 'asc']],
+                ],
             );
 
         $response = $datatables->getResponse();
@@ -856,9 +858,9 @@ final class DataTableTest extends TestCase
         $datatables = (new Builder())
             ->withColumnAliases(
                 [
-                    'id' => 't.id',
-                    'name' => 't.name'
-                ]
+                    'id'   => 't.id',
+                    'name' => 't.name',
+                ],
             )
             ->withIndexColumn('qlu.id')
             ->setUseOutputWalkers(false)
@@ -867,32 +869,32 @@ final class DataTableTest extends TestCase
             ->withQueryBuilder(
                 $doctrine->em->createQueryBuilder()
                     ->select('t.id, t.name')
-                    ->from(TestAttribute::class, 't')
+                    ->from(TestAttribute::class, 't'),
             )
             ->withRequestParams(
                 [
-                    'draw' => 1,
-                    'start' => 0,
-                    'length' => 10,
-                    'search' => ['value' => '', 'regex' => true ],
+                    'draw'    => 1,
+                    'start'   => 0,
+                    'length'  => 10,
+                    'search'  => ['value' => '', 'regex' => true],
                     'columns' => [
                         [
-                            'data' => 'id',
-                            'name' => 'id',
+                            'data'       => 'id',
+                            'name'       => 'id',
                             'searchable' => true,
-                            'orderable' => true,
-                            'search' => ['value' => '[><]2,3', 'regex' => false]
+                            'orderable'  => true,
+                            'search'     => ['value' => '[><]2,3', 'regex' => false],
                         ],
                         [
-                            'data' => 'name',
-                            'name' => 'name',
+                            'data'       => 'name',
+                            'name'       => 'name',
                             'searchable' => true,
-                            'orderable' => true,
-                            'search' => ['value' => '', 'regex' => false]
-                        ]
+                            'orderable'  => true,
+                            'search'     => ['value' => '', 'regex' => false],
+                        ],
                     ],
-                    'order' => [ [ 'column' => 0, 'dir' => 'asc'] ]
-                ]
+                    'order' => [['column' => 0, 'dir' => 'asc']],
+                ],
             );
 
         $response = $datatables->getResponse();
@@ -910,9 +912,9 @@ final class DataTableTest extends TestCase
         $datatables = (new Builder())
             ->withColumnAliases(
                 [
-                    'id' => 't.id',
-                    'name' => 't.name'
-                ]
+                    'id'   => 't.id',
+                    'name' => 't.name',
+                ],
             )
             ->withIndexColumn('qlu.id')
             ->setUseOutputWalkers(false)
@@ -921,32 +923,32 @@ final class DataTableTest extends TestCase
             ->withQueryBuilder(
                 $doctrine->em->createQueryBuilder()
                     ->select('t.id, t.name')
-                    ->from(TestAttribute::class, 't')
+                    ->from(TestAttribute::class, 't'),
             )
             ->withRequestParams(
                 [
-                    'draw' => 1,
-                    'start' => 0,
-                    'length' => 10,
-                    'search' => ['value' => '', 'regex' => true ],
+                    'draw'    => 1,
+                    'start'   => 0,
+                    'length'  => 10,
+                    'search'  => ['value' => '', 'regex' => true],
                     'columns' => [
                         [
-                            'data' => 'id',
-                            'name' => 'id',
+                            'data'       => 'id',
+                            'name'       => 'id',
                             'searchable' => true,
-                            'orderable' => true,
-                            'search' => ['value' => '[=]2', 'regex' => false]
+                            'orderable'  => true,
+                            'search'     => ['value' => '[=]2', 'regex' => false],
                         ],
                         [
-                            'data' => 'name',
-                            'name' => 'name',
+                            'data'       => 'name',
+                            'name'       => 'name',
                             'searchable' => true,
-                            'orderable' => true,
-                            'search' => ['value' => '', 'regex' => false]
-                        ]
+                            'orderable'  => true,
+                            'search'     => ['value' => '', 'regex' => false],
+                        ],
                     ],
-                    'order' => [ [ 'column' => 0, 'dir' => 'asc'] ]
-                ]
+                    'order' => [['column' => 0, 'dir' => 'asc']],
+                ],
             );
 
         $response = $datatables->getResponse();

--- a/tests/DataTableTest.php
+++ b/tests/DataTableTest.php
@@ -117,7 +117,7 @@ final class DataTableTest extends TestCase
                             'name'       => 'name',
                             'searchable' => true,
                             'orderable'  => true,
-                            'search'     => ['value' => 'name1', 'regex' => true],
+                            'search'     => ['value' => 'name1', 'regex' => false],
                         ],
                     ],
                     'order' => [['column' => 0, 'dir' => 'asc']],

--- a/tests/DataTablesBuilderEdgeCasesTest.php
+++ b/tests/DataTablesBuilderEdgeCasesTest.php
@@ -4,12 +4,17 @@ declare(strict_types=1);
 
 namespace Daycry\Doctrine\Tests;
 
+use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\Test\CIUnitTestCase;
 use Daycry\Doctrine\DataTables\Builder;
+use Doctrine\ORM\Query\Expr;
+use Doctrine\ORM\QueryBuilder as ORMQueryBuilder;
 
 /**
  * Additional edge case tests for DataTables Builder
  * Focuses on specific scenarios that caused the "6 LIKE :search" error
+ *
+ * @internal
  */
 final class DataTablesBuilderEdgeCasesTest extends CIUnitTestCase
 {
@@ -19,15 +24,16 @@ final class DataTablesBuilderEdgeCasesTest extends CIUnitTestCase
      */
     public function testOriginalErrorScenario(): void
     {
-        $builder = new class extends Builder {
+        $builder = new class () extends Builder {
             public function testFieldValidation($columnValue, int $columnIndex): array
             {
                 $fieldName = $this->resolveFieldName($columnValue, $columnIndex);
+
                 return [
-                    'original_value' => $columnValue,
-                    'resolved_field' => $fieldName,
-                    'is_valid_dql' => $this->isValidDQLField($fieldName),
-                    'would_cause_error' => !$this->isValidDQLField($fieldName)
+                    'original_value'    => $columnValue,
+                    'resolved_field'    => $fieldName,
+                    'is_valid_dql'      => $this->isValidDQLField($fieldName),
+                    'would_cause_error' => ! $this->isValidDQLField($fieldName),
                 ];
             }
         };
@@ -41,19 +47,27 @@ final class DataTablesBuilderEdgeCasesTest extends CIUnitTestCase
 
         foreach ($problematicColumns as $column) {
             $result = $builder->testFieldValidation($column['data'], $column['index']);
-            
+
             if ($column['data'] === 6) {
                 // The problematic case should be caught and marked invalid
-                $this->assertFalse($result['is_valid_dql'], 
-                    "Numeric field '{$column['data']}' should be invalid to prevent DQL error");
-                $this->assertTrue($result['would_cause_error'],
-                    "Numeric field '{$column['data']}' would have caused the original error");
+                $this->assertFalse(
+                    $result['is_valid_dql'],
+                    "Numeric field '{$column['data']}' should be invalid to prevent DQL error",
+                );
+                $this->assertTrue(
+                    $result['would_cause_error'],
+                    "Numeric field '{$column['data']}' would have caused the original error",
+                );
             } else {
                 // Valid cases should pass
-                $this->assertTrue($result['is_valid_dql'],
-                    "Valid field '{$column['data']}' should be accepted");
-                $this->assertFalse($result['would_cause_error'],
-                    "Valid field '{$column['data']}' should not cause errors");
+                $this->assertTrue(
+                    $result['is_valid_dql'],
+                    "Valid field '{$column['data']}' should be accepted",
+                );
+                $this->assertFalse(
+                    $result['would_cause_error'],
+                    "Valid field '{$column['data']}' should not cause errors",
+                );
             }
         }
     }
@@ -63,18 +77,18 @@ final class DataTablesBuilderEdgeCasesTest extends CIUnitTestCase
      */
     public function testVariousDataTablesConfigurations(): void
     {
-        $builder = new class extends Builder {
+        $builder = new class () extends Builder {
             public function testColumnProcessing(array $column, int $index): array
             {
                 $searchable = $this->isColumnSearchable($column);
-                $fieldName = $this->resolveFieldName($column[$this->columnField] ?? '', $index);
-                $validDQL = $this->isValidDQLField($fieldName);
-                
+                $fieldName  = $this->resolveFieldName($column[$this->columnField] ?? '', $index);
+                $validDQL   = $this->isValidDQLField($fieldName);
+
                 return [
-                    'searchable' => $searchable,
-                    'field_name' => $fieldName,
-                    'valid_dql' => $validDQL,
-                    'would_be_processed' => $searchable && $validDQL
+                    'searchable'         => $searchable,
+                    'field_name'         => $fieldName,
+                    'valid_dql'          => $validDQL,
+                    'would_be_processed' => $searchable && $validDQL,
                 ];
             }
         };
@@ -82,56 +96,56 @@ final class DataTablesBuilderEdgeCasesTest extends CIUnitTestCase
         $testCases = [
             // Standard valid column
             [
-                'column' => ['data' => 'name', 'searchable' => 'true'],
-                'index' => 0,
+                'column'             => ['data' => 'name', 'searchable' => 'true'],
+                'index'              => 0,
                 'expected_processed' => true,
-                'description' => 'Standard valid column'
+                'description'        => 'Standard valid column',
             ],
             // Numeric data (the problematic case)
             [
-                'column' => ['data' => 6, 'searchable' => 'true'],
-                'index' => 2,
+                'column'             => ['data' => 6, 'searchable' => 'true'],
+                'index'              => 2,
                 'expected_processed' => false,
-                'description' => 'Numeric data causing "6 LIKE :search"'
+                'description'        => 'Numeric data causing "6 LIKE :search"',
             ],
             // Empty data
             [
-                'column' => ['data' => '', 'searchable' => 'true'],
-                'index' => 1,
+                'column'             => ['data' => '', 'searchable' => 'true'],
+                'index'              => 1,
                 'expected_processed' => false,
-                'description' => 'Empty data field'
+                'description'        => 'Empty data field',
             ],
             // Missing data field
             [
-                'column' => ['searchable' => 'true'],
-                'index' => 3,
+                'column'             => ['searchable' => 'true'],
+                'index'              => 3,
                 'expected_processed' => false,
-                'description' => 'Missing data field'
+                'description'        => 'Missing data field',
             ],
             // Not searchable
             [
-                'column' => ['data' => 'name', 'searchable' => 'false'],
-                'index' => 0,
+                'column'             => ['data' => 'name', 'searchable' => 'false'],
+                'index'              => 0,
                 'expected_processed' => false,
-                'description' => 'Not searchable column'
+                'description'        => 'Not searchable column',
             ],
             // String numeric (also problematic)
             [
-                'column' => ['data' => '123', 'searchable' => 'true'],
-                'index' => 4,
+                'column'             => ['data' => '123', 'searchable' => 'true'],
+                'index'              => 4,
                 'expected_processed' => false,
-                'description' => 'String numeric data'
-            ]
+                'description'        => 'String numeric data',
+            ],
         ];
 
         foreach ($testCases as $testCase) {
             $result = $builder->testColumnProcessing($testCase['column'], $testCase['index']);
-            
-            $this->assertEquals(
+
+            $this->assertSame(
                 $testCase['expected_processed'],
                 $result['would_be_processed'],
                 "Failed for: {$testCase['description']} - " .
-                "Expected processed: {$testCase['expected_processed']}, got: {$result['would_be_processed']}"
+                "Expected processed: {$testCase['expected_processed']}, got: {$result['would_be_processed']}",
             );
         }
     }
@@ -143,25 +157,26 @@ final class DataTablesBuilderEdgeCasesTest extends CIUnitTestCase
     {
         $builder = Builder::create()
             ->withColumnAliases([
-                'name' => 'u.name',
+                'name'  => 'u.name',
                 'email' => 'u.email',
-                'n6' => 'invalid.field',  // Even if aliased, numeric-value keys should be caught
-                '' => 'empty.field'       // Empty keys
+                'n6'    => 'invalid.field',  // Even if aliased, numeric-value keys should be caught
+                ''      => 'empty.field',       // Empty keys
             ]);
 
-        $testBuilder = new class($builder) extends Builder {
+        $testBuilder = new class ($builder) extends Builder {
             public function __construct(Builder $parent)
             {
                 $this->columnAliases = $parent->columnAliases;
             }
-            
+
             public function testResolveAndValidate($columnValue, int $columnIndex): array
             {
                 $fieldName = $this->resolveFieldName($columnValue, $columnIndex);
+
                 return [
                     'original' => $columnValue,
                     'resolved' => $fieldName,
-                    'valid' => $this->isValidDQLField($fieldName)
+                    'valid'    => $this->isValidDQLField($fieldName),
                 ];
             }
         };
@@ -175,13 +190,13 @@ final class DataTablesBuilderEdgeCasesTest extends CIUnitTestCase
 
         foreach ($testCases as $testCase) {
             $result = $testBuilder->testResolveAndValidate($testCase['value'], $testCase['index']);
-            
-            $this->assertEquals(
+
+            $this->assertSame(
                 $testCase['should_be_valid'],
                 $result['valid'],
                 "Failed for value '{$testCase['value']}' at index {$testCase['index']}: " .
-                "Expected valid: " . ($testCase['should_be_valid'] ? 'true' : 'false') . 
-                ", got: " . ($result['valid'] ? 'true' : 'false')
+                'Expected valid: ' . ($testCase['should_be_valid'] ? 'true' : 'false') .
+                ', got: ' . ($result['valid'] ? 'true' : 'false'),
             );
         }
     }
@@ -193,21 +208,21 @@ final class DataTablesBuilderEdgeCasesTest extends CIUnitTestCase
     {
         $testCases = [
             // Standard valid cases
-            '[=]test' => '=',
-            '[!=]value' => '!=',
+            '[=]test'      => '=',
+            '[!=]value'    => '!=',
             '[LIKE]search' => '%',  // Should normalize to %
-            
+
             // Edge cases and malformed input
             '[INVALID]test' => '%',      // Invalid operator
-            '[123]test' => '%',          // Numeric operator
-            '[=]' => '=',                // No value after operator
-            'test' => '%',               // No operator brackets
-            '' => '%',                   // Empty string
-            '[' => '%',                  // Incomplete bracket
-            '[]test' => '%',             // Empty operator
-            '[=test' => '%',             // Missing closing bracket
-            '=]test' => '%',             // Missing opening bracket
-            
+            '[123]test'     => '%',          // Numeric operator
+            '[=]'           => '=',                // No value after operator
+            'test'          => '%',               // No operator brackets
+            ''              => '%',                   // Empty string
+            '['             => '%',                  // Incomplete bracket
+            '[]test'        => '%',             // Empty operator
+            '[=test'        => '%',             // Missing closing bracket
+            '=]test'        => '%',             // Missing opening bracket
+
             // Case sensitivity
             '[like]test' => '%',         // Lowercase should work
             '[Like]test' => '%',         // Mixed case should work
@@ -216,21 +231,21 @@ final class DataTablesBuilderEdgeCasesTest extends CIUnitTestCase
         foreach ($testCases as $input => $expectedOperator) {
             // Simulate the operator parsing logic from Builder
             $actualOperator = preg_match('~^\[(?<operator>[A-Z!=%<>•]+)\].*$~i', $input, $matches) ? strtoupper($matches['operator']) : '%•';
-            
+
             // Apply normalization
             if (in_array($actualOperator, ['LIKE', '%%'], true)) {
                 $actualOperator = '%';
             }
-            
+
             $validOperators = ['!=', '<', '>', 'IN', 'OR', '><', '=', '%'];
-            if (!in_array($actualOperator, $validOperators, true)) {
+            if (! in_array($actualOperator, $validOperators, true)) {
                 $actualOperator = '%';
             }
 
-            $this->assertEquals(
+            $this->assertSame(
                 $expectedOperator,
                 $actualOperator,
-                "Failed parsing operator from input: '{$input}'"
+                "Failed parsing operator from input: '{$input}'",
             );
         }
     }
@@ -240,16 +255,16 @@ final class DataTablesBuilderEdgeCasesTest extends CIUnitTestCase
      */
     public function testSearchableColumnsRestrictionEdgeCases(): void
     {
-        $builder = new class extends Builder {
+        $builder = new class () extends Builder {
             public function testSearchableRestriction(array $searchableColumns, string $field): bool
             {
                 $this->searchableColumns = $searchableColumns;
-                
+
                 // Empty searchableColumns means all valid fields are allowed
                 if (empty($this->searchableColumns)) {
                     return true;
                 }
-                
+
                 // Check if field is in the allowed list
                 return in_array($field, $this->searchableColumns, true);
             }
@@ -261,21 +276,22 @@ final class DataTablesBuilderEdgeCasesTest extends CIUnitTestCase
 
         // Test with specific restrictions
         $allowedColumns = ['name', 'email', 'company'];
-        
+
         // Allowed fields should pass
         foreach ($allowedColumns as $column) {
             $this->assertTrue(
                 $builder->testSearchableRestriction($allowedColumns, $column),
-                "Field '{$column}' should be allowed when in searchable columns list"
+                "Field '{$column}' should be allowed when in searchable columns list",
             );
         }
 
         // Disallowed fields should be rejected
         $disallowedFields = ['password', 'secret', 'internal_id'];
+
         foreach ($disallowedFields as $field) {
             $this->assertFalse(
                 $builder->testSearchableRestriction($allowedColumns, $field),
-                "Field '{$field}' should be rejected when not in searchable columns list"
+                "Field '{$field}' should be rejected when not in searchable columns list",
             );
         }
     }
@@ -287,76 +303,76 @@ final class DataTablesBuilderEdgeCasesTest extends CIUnitTestCase
     {
         // Simulate the exact request that caused the original error
         $problematicRequest = [
-            'draw' => 1,
-            'start' => 0,
-            'length' => 10,
+            'draw'    => 1,
+            'start'   => 0,
+            'length'  => 10,
             'columns' => [
                 [
-                    'data' => 'name',
+                    'data'       => 'name',
                     'searchable' => 'true',
-                    'search' => ['value' => '']
+                    'search'     => ['value' => ''],
                 ],
                 [
-                    'data' => 'companyName', 
+                    'data'       => 'companyName',
                     'searchable' => 'true',
-                    'search' => ['value' => '']
+                    'search'     => ['value' => ''],
                 ],
                 [
-                    'data' => 6,  // This would cause "6 LIKE :search"
+                    'data'       => 6,  // This would cause "6 LIKE :search"
                     'searchable' => 'true',
-                    'search' => ['value' => '']
-                ]
+                    'search'     => ['value' => ''],
+                ],
             ],
-            'search' => ['value' => 'test_search']
+            'search' => ['value' => 'test_search'],
         ];
 
-        $builder = new class extends Builder {
+        $builder = new class () extends Builder {
             public function simulateGlobalSearch(array $requestParams): array
             {
                 $this->requestParams = $requestParams;
-                $columns = $requestParams['columns'];
-                $searchValue = $requestParams['search']['value'] ?? '';
-                
+                $columns             = $requestParams['columns'];
+                $searchValue         = $requestParams['search']['value'] ?? '';
+
                 $processedColumns = [];
-                $skippedColumns = [];
-                
+                $skippedColumns   = [];
+
                 if ($searchValue) {
                     for ($i = 0; $i < count($columns); $i++) {
                         $column = $columns[$i];
-                        
+
                         if ($this->isColumnSearchable($column)) {
                             $fieldName = $this->resolveFieldName($column[$this->columnField] ?? '', $i);
-                            
+
                             if ($this->isValidDQLField($fieldName)) {
                                 $processedColumns[] = [
-                                    'index' => $i,
-                                    'original_data' => $column['data'],
+                                    'index'          => $i,
+                                    'original_data'  => $column['data'],
                                     'resolved_field' => $fieldName,
-                                    'status' => 'processed'
+                                    'status'         => 'processed',
                                 ];
                             } else {
                                 $skippedColumns[] = [
-                                    'index' => $i,
-                                    'original_data' => $column['data'],
+                                    'index'          => $i,
+                                    'original_data'  => $column['data'],
                                     'resolved_field' => $fieldName,
-                                    'status' => 'skipped_invalid_dql'
+                                    'status'         => 'skipped_invalid_dql',
                                 ];
                             }
                         } else {
                             $skippedColumns[] = [
-                                'index' => $i,
-                                'original_data' => $column['data'] ?? 'missing',
+                                'index'          => $i,
+                                'original_data'  => $column['data'] ?? 'missing',
                                 'resolved_field' => 'N/A',
-                                'status' => 'skipped_not_searchable'
+                                'status'         => 'skipped_not_searchable',
                             ];
                         }
                     }
                 }
-                
+
                 return [
-                    'processed' => $processedColumns,
-                    'skipped' => $skippedColumns,
-                    'would_have_error' => !empty($skippedColumns)
+                    'processed'        => $processedColumns,
+                    'skipped'          => $skippedColumns,
+                    'would_have_error' => ! empty($skippedColumns),
                 ];
             }
         };
@@ -365,17 +381,102 @@ final class DataTablesBuilderEdgeCasesTest extends CIUnitTestCase
 
         // Should have processed the valid columns
         $this->assertCount(2, $result['processed'], 'Should process 2 valid columns');
-        $this->assertEquals('name', $result['processed'][0]['resolved_field']);
-        $this->assertEquals('companyName', $result['processed'][1]['resolved_field']);
+        $this->assertSame('name', $result['processed'][0]['resolved_field']);
+        $this->assertSame('companyName', $result['processed'][1]['resolved_field']);
 
         // Should have skipped the problematic column
         $this->assertCount(1, $result['skipped'], 'Should skip 1 invalid column');
-        $this->assertEquals(6, $result['skipped'][0]['original_data']);
-        $this->assertEquals('2', $result['skipped'][0]['resolved_field']); // Index as string
-        $this->assertEquals('skipped_invalid_dql', $result['skipped'][0]['status']);
+        $this->assertSame(6, $result['skipped'][0]['original_data']);
+        $this->assertSame('2', $result['skipped'][0]['resolved_field']); // Index as string
+        $this->assertSame('skipped_invalid_dql', $result['skipped'][0]['status']);
 
         // The fix should prevent the error
         $this->assertTrue($result['would_have_error'], 'Original request would have caused error, but now it is handled');
+    }
+
+    public function testBetweenOperatorThrowsWithSingleValue(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('BETWEEN operator [><] requires exactly 2 comma-separated values, got 1.');
+
+        $qb = $this->createMock(ORMQueryBuilder::class);
+        $qb->method('expr')->willReturn(new Expr());
+
+        Builder::create()
+            ->withQueryBuilder($qb)
+            ->withRequestParams([
+                'columns' => [
+                    [
+                        'data'       => 'price',
+                        'searchable' => true,
+                        'search'     => ['value' => '[><]50'],
+                    ],
+                ],
+            ])
+            ->getFilteredQuery();
+    }
+
+    public function testBetweenOperatorThrowsWithThreeValues(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('BETWEEN operator [><] requires exactly 2 comma-separated values, got 3.');
+
+        $qb = $this->createMock(ORMQueryBuilder::class);
+        $qb->method('expr')->willReturn(new Expr());
+
+        Builder::create()
+            ->withQueryBuilder($qb)
+            ->withRequestParams([
+                'columns' => [
+                    [
+                        'data'       => 'price',
+                        'searchable' => true,
+                        'search'     => ['value' => '[><]1,2,3'],
+                    ],
+                ],
+            ])
+            ->getFilteredQuery();
+    }
+
+    public function testGlobalRegexSearchIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Regex search is not supported');
+
+        $qb = $this->createMock(ORMQueryBuilder::class);
+        $qb->method('expr')->willReturn(new Expr());
+
+        Builder::create()
+            ->withQueryBuilder($qb)
+            ->withRequestParams([
+                'search'  => ['value' => 'test', 'regex' => true],
+                'columns' => [
+                    ['data' => 'name', 'searchable' => true, 'search' => ['value' => '']],
+                ],
+            ])
+            ->getFilteredQuery();
+    }
+
+    public function testPerColumnRegexSearchIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Regex per-column search is not supported');
+
+        $qb = $this->createMock(ORMQueryBuilder::class);
+        $qb->method('expr')->willReturn(new Expr());
+
+        Builder::create()
+            ->withQueryBuilder($qb)
+            ->withRequestParams([
+                'columns' => [
+                    [
+                        'data'       => 'name',
+                        'searchable' => true,
+                        'search'     => ['value' => 'pattern', 'regex' => true],
+                    ],
+                ],
+            ])
+            ->getFilteredQuery();
     }
 
     /**
@@ -383,57 +484,66 @@ final class DataTablesBuilderEdgeCasesTest extends CIUnitTestCase
      */
     public function testPerformanceWithLargeColumnSets(): void
     {
-        $builder = new class extends Builder {
+        $builder = new class () extends Builder {
             public function testLargeColumnProcessing(int $columnCount): array
             {
                 $startTime = microtime(true);
-                
+
                 $processedCount = 0;
-                $skippedCount = 0;
-                
+                $skippedCount   = 0;
+
                 for ($i = 0; $i < $columnCount; $i++) {
                     // Mix of valid and invalid columns
                     $columnValue = ($i % 3 === 0) ? $i : "field_{$i}"; // Every 3rd is numeric
-                    
+
                     $fieldName = $this->resolveFieldName($columnValue, $i);
-                    
+
                     if ($this->isValidDQLField($fieldName)) {
                         $processedCount++;
                     } else {
                         $skippedCount++;
                     }
                 }
-                
+
                 $endTime = microtime(true);
-                
+
                 return [
-                    'column_count' => $columnCount,
-                    'processed' => $processedCount,
-                    'skipped' => $skippedCount,
-                    'execution_time' => $endTime - $startTime,
-                    'avg_time_per_column' => ($endTime - $startTime) / $columnCount
+                    'column_count'        => $columnCount,
+                    'processed'           => $processedCount,
+                    'skipped'             => $skippedCount,
+                    'execution_time'      => $endTime - $startTime,
+                    'avg_time_per_column' => ($endTime - $startTime) / $columnCount,
                 ];
             }
         };
 
         // Test with various column counts
         $columnCounts = [10, 50, 100];
-        
+
         foreach ($columnCounts as $count) {
             $result = $builder->testLargeColumnProcessing($count);
-            
+
             // Performance should be reasonable (less than 1ms per column)
-            $this->assertLessThan(0.001, $result['avg_time_per_column'], 
-                "Processing {$count} columns should be fast");
-            
+            $this->assertLessThan(
+                0.001,
+                $result['avg_time_per_column'],
+                "Processing {$count} columns should be fast",
+            );
+
             // Should correctly identify valid vs invalid columns
-            $expectedSkipped = intval($count / 3); // Every 3rd column starting from 0
+            $expectedSkipped   = (int) ($count / 3); // Every 3rd column starting from 0
             $expectedProcessed = $count - $expectedSkipped;
-            
-            $this->assertGreaterThan(0, $result['processed'], 
-                "Should process some valid columns");
-            $this->assertGreaterThan(0, $result['skipped'], 
-                "Should skip some invalid columns");
+
+            $this->assertGreaterThan(
+                0,
+                $result['processed'],
+                'Should process some valid columns',
+            );
+            $this->assertGreaterThan(
+                0,
+                $result['skipped'],
+                'Should skip some invalid columns',
+            );
         }
     }
 }

--- a/tests/DataTablesBuilderTest.php
+++ b/tests/DataTablesBuilderTest.php
@@ -4,14 +4,16 @@ declare(strict_types=1);
 
 namespace Daycry\Doctrine\Tests;
 
-use Doctrine\ORM\QueryBuilder;
 use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\Test\CIUnitTestCase;
 use Daycry\Doctrine\DataTables\Builder;
+use Doctrine\ORM\QueryBuilder;
 
 /**
  * Comprehensive tests for DataTables Builder
  * Tests the fix for "6 LIKE :search" error and all edge cases
+ *
+ * @internal
  */
 final class DataTablesBuilderTest extends CIUnitTestCase
 {
@@ -37,7 +39,7 @@ final class DataTablesBuilderTest extends CIUnitTestCase
      */
     public function testResolveFieldNameWithValidField(): void
     {
-        $builder = new class extends Builder {
+        $builder = new class () extends Builder {
             public function testResolveFieldName($columnValue, int $columnIndex): string
             {
                 return $this->resolveFieldName($columnValue, $columnIndex);
@@ -54,7 +56,7 @@ final class DataTablesBuilderTest extends CIUnitTestCase
      */
     public function testResolveFieldNameWithNumericValue(): void
     {
-        $builder = new class extends Builder {
+        $builder = new class () extends Builder {
             public function testResolveFieldName($columnValue, int $columnIndex): string
             {
                 return $this->resolveFieldName($columnValue, $columnIndex);
@@ -63,10 +65,10 @@ final class DataTablesBuilderTest extends CIUnitTestCase
 
         // Numeric values should return the column index as string
         $result = $builder->testResolveFieldName(6, 2);
-        $this->assertEquals('2', $result);
-        
+        $this->assertSame('2', $result);
+
         $result = $builder->testResolveFieldName('123', 1);
-        $this->assertEquals('1', $result);
+        $this->assertSame('1', $result);
     }
 
     /**
@@ -74,7 +76,7 @@ final class DataTablesBuilderTest extends CIUnitTestCase
      */
     public function testResolveFieldNameWithEmptyValue(): void
     {
-        $builder = new class extends Builder {
+        $builder = new class () extends Builder {
             public function testResolveFieldName($columnValue, int $columnIndex): string
             {
                 return $this->resolveFieldName($columnValue, $columnIndex);
@@ -82,10 +84,10 @@ final class DataTablesBuilderTest extends CIUnitTestCase
         };
 
         $result = $builder->testResolveFieldName('', 3);
-        $this->assertEquals('3', $result);
-        
+        $this->assertSame('3', $result);
+
         $result = $builder->testResolveFieldName(null, 4);
-        $this->assertEquals('4', $result);
+        $this->assertSame('4', $result);
     }
 
     /**
@@ -93,7 +95,7 @@ final class DataTablesBuilderTest extends CIUnitTestCase
      */
     public function testResolveFieldNameWithAlias(): void
     {
-        $builder = new class extends Builder {
+        $builder = new class () extends Builder {
             public function testResolveFieldName($columnValue, int $columnIndex): string
             {
                 return $this->resolveFieldName($columnValue, $columnIndex);
@@ -101,13 +103,13 @@ final class DataTablesBuilderTest extends CIUnitTestCase
         };
 
         $builder->withColumnAliases(['name' => 'p.name', 'email' => 'u.email']);
-        
+
         $result = $builder->testResolveFieldName('name', 0);
         $this->assertSame('p.name', $result);
-        
+
         $result = $builder->testResolveFieldName('email', 1);
         $this->assertSame('u.email', $result);
-        
+
         // Non-aliased field should remain unchanged
         $result = $builder->testResolveFieldName('company', 2);
         $this->assertSame('company', $result);
@@ -118,7 +120,7 @@ final class DataTablesBuilderTest extends CIUnitTestCase
      */
     public function testIsValidDQLFieldWithValidFields(): void
     {
-        $builder = new class extends Builder {
+        $builder = new class () extends Builder {
             public function testIsValidDQLField(string $field): bool
             {
                 return $this->isValidDQLField($field);
@@ -139,7 +141,7 @@ final class DataTablesBuilderTest extends CIUnitTestCase
      */
     public function testIsValidDQLFieldWithInvalidFields(): void
     {
-        $builder = new class extends Builder {
+        $builder = new class () extends Builder {
             public function testIsValidDQLField(string $field): bool
             {
                 return $this->isValidDQLField($field);
@@ -162,7 +164,7 @@ final class DataTablesBuilderTest extends CIUnitTestCase
      */
     public function testIsColumnSearchable(): void
     {
-        $builder = new class extends Builder {
+        $builder = new class () extends Builder {
             public function testIsColumnSearchable(array $column): bool
             {
                 return $this->isColumnSearchable($column);
@@ -172,41 +174,41 @@ final class DataTablesBuilderTest extends CIUnitTestCase
         // Valid searchable column with boolean true
         $this->assertTrue($builder->testIsColumnSearchable([
             'searchable' => true,
-            'data' => 'name'
+            'data'       => 'name',
         ]));
 
         // Valid searchable column with string 'true' (DataTables sends this)
         $this->assertTrue($builder->testIsColumnSearchable([
             'searchable' => 'true',
-            'data' => 'name'
+            'data'       => 'name',
         ]));
 
         // Not searchable (boolean false)
         $this->assertFalse($builder->testIsColumnSearchable([
             'searchable' => false,
-            'data' => 'name'
+            'data'       => 'name',
         ]));
 
         // Not searchable (string 'false')
         $this->assertFalse($builder->testIsColumnSearchable([
             'searchable' => 'false',
-            'data' => 'name'
+            'data'       => 'name',
         ]));
 
         // Missing searchable field
         $this->assertFalse($builder->testIsColumnSearchable([
-            'data' => 'name'
+            'data' => 'name',
         ]));
 
         // Missing data field
         $this->assertFalse($builder->testIsColumnSearchable([
-            'searchable' => true
+            'searchable' => true,
         ]));
 
         // Empty data field
         $this->assertFalse($builder->testIsColumnSearchable([
             'searchable' => true,
-            'data' => ''
+            'data'       => '',
         ]));
     }
 
@@ -222,7 +224,7 @@ final class DataTablesBuilderTest extends CIUnitTestCase
             ->withColumnField('data')
             ->withIndexColumn('id')
             ->setUseOutputWalkers(false);
-        
+
         $this->assertSame($this->builder, $result);
     }
 
@@ -234,7 +236,7 @@ final class DataTablesBuilderTest extends CIUnitTestCase
         // Test missing QueryBuilder
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('QueryBuilder is not set.');
-        
+
         $this->builder
             ->withRequestParams(['columns' => [['data' => 'name']]])
             ->getData();
@@ -246,10 +248,10 @@ final class DataTablesBuilderTest extends CIUnitTestCase
     public function testValidationMissingColumns(): void
     {
         $queryBuilder = $this->createStub(QueryBuilder::class);
-        
+
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Request parameters or columns are not set.');
-        
+
         $this->builder
             ->withQueryBuilder($queryBuilder)
             ->withRequestParams([])
@@ -262,10 +264,10 @@ final class DataTablesBuilderTest extends CIUnitTestCase
     public function testValidationEmptyColumns(): void
     {
         $queryBuilder = $this->createStub(QueryBuilder::class);
-        
+
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Request parameters or columns are not set.');
-        
+
         $this->builder
             ->withQueryBuilder($queryBuilder)
             ->withRequestParams(['columns' => []])
@@ -277,22 +279,22 @@ final class DataTablesBuilderTest extends CIUnitTestCase
      */
     public function testFilterOperatorParsing(): void
     {
-        $builder = new class extends Builder {
+        $builder = new class () extends Builder {
             public function testParseOperator(string $value): string
             {
                 // Simulate the operator parsing logic from getFilteredQuery
                 $operator = preg_match('~^\[(?<operator>[A-Z!=%<>•]+)\].*$~i', $value, $matches) ? strtoupper($matches['operator']) : '%•';
-                
+
                 // Normalize operator
                 if (in_array($operator, ['LIKE', '%%'], true)) {
                     $operator = '%';
                 }
-                
+
                 $validOperators = ['!=', '<', '>', 'IN', 'OR', '><', '=', '%'];
-                if (!in_array($operator, $validOperators, true)) {
+                if (! in_array($operator, $validOperators, true)) {
                     $operator = '%';
                 }
-                
+
                 return $operator;
             }
         };
@@ -310,11 +312,11 @@ final class DataTablesBuilderTest extends CIUnitTestCase
         // Test operator normalization
         $this->assertSame('%', $builder->testParseOperator('[LIKE]test'));
         $this->assertSame('%', $builder->testParseOperator('[%%]test'));
-        
+
         // Test invalid operators default to %
         $this->assertSame('%', $builder->testParseOperator('[INVALID]test'));
         $this->assertSame('%', $builder->testParseOperator('[XYZ]test'));
-        
+
         // Test no operator defaults to %
         $this->assertSame('%', $builder->testParseOperator('test'));
     }
@@ -324,17 +326,14 @@ final class DataTablesBuilderTest extends CIUnitTestCase
      */
     public function testSearchableColumnsRestriction(): void
     {
-        $builder = new class extends Builder {
+        $builder = new class () extends Builder {
             public function testSearchableRestriction(array $searchableColumns, string $field): bool
             {
                 $this->searchableColumns = $searchableColumns;
 
                 // Simulate the logic from getFilteredQuery
-                if (!empty($this->searchableColumns) && !in_array($field, $this->searchableColumns, true)) {
-                    return false; // Should be skipped
-                }
-
-                return true; // Should be included
+                return ! (! empty($this->searchableColumns) && ! in_array($field, $this->searchableColumns, true));
+                // Should be skipped// Should be included
             }
         };
 
@@ -354,18 +353,19 @@ final class DataTablesBuilderTest extends CIUnitTestCase
      */
     public function testCompleteFieldValidationPipeline(): void
     {
-        $builder = new class extends Builder {
+        $builder = new class () extends Builder {
             public function testFieldValidationPipeline($columnValue, int $columnIndex, array $searchableColumns = []): bool
             {
                 $this->searchableColumns = $searchableColumns;
-                
+
                 // Step 1: Resolve field name
                 $fieldName = $this->resolveFieldName($columnValue, $columnIndex);
-                
+
                 // Step 2: Check searchable columns restriction
-                if (!empty($this->searchableColumns) && !in_array($fieldName, $this->searchableColumns, true)) {
+                if (! empty($this->searchableColumns) && ! in_array($fieldName, $this->searchableColumns, true)) {
                     return false;
                 }
+
                 // Step 3: Validate DQL field (this prevents "6 LIKE :search")
                 return $this->isValidDQLField($fieldName);
             }
@@ -393,7 +393,7 @@ final class DataTablesBuilderTest extends CIUnitTestCase
      */
     public function testEdgeCasesThatCausedOriginalError(): void
     {
-        $builder = new class extends Builder {
+        $builder = new class () extends Builder {
             public function testIsValidDQLField(string $field): bool
             {
                 return $this->isValidDQLField($field);
@@ -404,7 +404,7 @@ final class DataTablesBuilderTest extends CIUnitTestCase
         $problematicValues = [
             '6',      // The original problem case
             '0',      // First column index
-            '1',      // Second column index  
+            '1',      // Second column index
             '10',     // Double digit
             '123',    // Multi-digit
         ];
@@ -412,7 +412,7 @@ final class DataTablesBuilderTest extends CIUnitTestCase
         foreach ($problematicValues as $value) {
             $this->assertFalse(
                 $builder->testIsValidDQLField($value),
-                "Field '{$value}' should be invalid to prevent DQL syntax errors"
+                "Field '{$value}' should be invalid to prevent DQL syntax errors",
             );
         }
     }

--- a/tests/DoctrineCacheArrayTest.php
+++ b/tests/DoctrineCacheArrayTest.php
@@ -4,37 +4,39 @@ declare(strict_types=1);
 
 namespace Tests;
 
+use Daycry\Doctrine\Doctrine;
 use Doctrine\ORM\EntityManager;
 use Psr\Cache\CacheItemPoolInterface;
-use Daycry\Doctrine\Doctrine;
-use Config\Cache;
 use Tests\Support\TestCase;
 
+/**
+ * @internal
+ */
 final class DoctrineCacheArrayTest extends TestCase
 {
     public function testDoctrineWithArrayCache()
     {
-        $cacheConf = config('Cache');
+        $cacheConf          = config('Cache');
         $cacheConf->handler = 'dummy'; // Fallback to ArrayAdapter
-        $doctrine = new Doctrine($this->config, $cacheConf);
+        $doctrine           = new Doctrine($this->config, $cacheConf);
         $this->assertInstanceOf(Doctrine::class, $doctrine);
         $this->assertInstanceOf(EntityManager::class, $doctrine->em);
     }
 
     public function testDoctrineArrayCachePersistsData()
     {
-        $cacheConf = config('Cache');
+        $cacheConf          = config('Cache');
         $cacheConf->handler = 'dummy';
-        $doctrine = new Doctrine($this->config, $cacheConf);
-        $cache = $doctrine->em->getConfiguration()->getQueryCache();
-        $key = 'test_doctrine_array_cache';
-        $value = ['foo' => 'bar', 'baz' => 123];
+        $doctrine           = new Doctrine($this->config, $cacheConf);
+        $cache              = $doctrine->em->getConfiguration()->getQueryCache();
+        $key                = 'test_doctrine_array_cache';
+        $value              = ['foo' => 'bar', 'baz' => 123];
         $this->assertInstanceOf(CacheItemPoolInterface::class, $cache);
         $cache->deleteItem($key);
         $cache->save($cache->getItem($key)->set($value));
         $item = $cache->getItem($key);
         $this->assertTrue($item->isHit(), 'El valor debería estar en caché');
-        $this->assertEquals($value, $item->get());
+        $this->assertSame($value, $item->get());
         $cache->deleteItem($key);
     }
 }

--- a/tests/DoctrineCacheFileTest.php
+++ b/tests/DoctrineCacheFileTest.php
@@ -4,35 +4,37 @@ declare(strict_types=1);
 
 namespace Tests;
 
-use Doctrine\ORM\EntityManager;
 use Daycry\Doctrine\Doctrine;
-use Config\Cache;
+use Doctrine\ORM\EntityManager;
 use Tests\Support\TestCase;
 
+/**
+ * @internal
+ */
 final class DoctrineCacheFileTest extends TestCase
 {
     public function testDoctrineWithFileCache()
     {
-        $cacheConf = config('Cache');
+        $cacheConf          = config('Cache');
         $cacheConf->handler = 'file';
-        $doctrine = new Doctrine($this->config, $cacheConf);
+        $doctrine           = new Doctrine($this->config, $cacheConf);
         $this->assertInstanceOf(Doctrine::class, $doctrine);
         $this->assertInstanceOf(EntityManager::class, $doctrine->em);
     }
 
     public function testDoctrineFileCachePersistsData()
     {
-        $cacheConf = config('Cache');
+        $cacheConf          = config('Cache');
         $cacheConf->handler = 'file';
-        $doctrine = new Doctrine($this->config, $cacheConf);
-        $cache = $doctrine->em->getConfiguration()->getQueryCache();
-        $key = 'test_doctrine_file_cache';
-        $value = ['foo' => 'bar', 'baz' => 123];
+        $doctrine           = new Doctrine($this->config, $cacheConf);
+        $cache              = $doctrine->em->getConfiguration()->getQueryCache();
+        $key                = 'test_doctrine_file_cache';
+        $value              = ['foo' => 'bar', 'baz' => 123];
         $cache->deleteItem($key); // Limpia antes
         $cache->save($cache->getItem($key)->set($value));
         $item = $cache->getItem($key);
         $this->assertTrue($item->isHit(), 'El valor debería estar en caché');
-        $this->assertEquals($value, $item->get());
+        $this->assertSame($value, $item->get());
         $cache->deleteItem($key); // Limpia después
     }
 }

--- a/tests/DoctrineCacheMemcachedTest.php
+++ b/tests/DoctrineCacheMemcachedTest.php
@@ -4,41 +4,43 @@ declare(strict_types=1);
 
 namespace Tests;
 
-use Doctrine\ORM\EntityManager;
 use Daycry\Doctrine\Doctrine;
-use Config\Cache;
+use Doctrine\ORM\EntityManager;
 use Tests\Support\TestCase;
 
+/**
+ * @internal
+ */
 final class DoctrineCacheMemcachedTest extends TestCase
 {
     public function testDoctrineWithMemcachedCache()
     {
-        if (!extension_loaded('memcached')) {
+        if (! extension_loaded('memcached')) {
             $this->markTestSkipped('La extensión memcached no está habilitada.');
         }
-        $cacheConf = config('Cache');
+        $cacheConf          = config('Cache');
         $cacheConf->handler = 'memcached';
-        $doctrine = new Doctrine($this->config, $cacheConf);
+        $doctrine           = new Doctrine($this->config, $cacheConf);
         $this->assertInstanceOf(Doctrine::class, $doctrine);
         $this->assertInstanceOf(EntityManager::class, $doctrine->em);
     }
 
     public function testDoctrineMemcachedCachePersistsData()
     {
-        if (!extension_loaded('memcached')) {
+        if (! extension_loaded('memcached')) {
             $this->markTestSkipped('La extensión memcached no está habilitada.');
         }
-        $cacheConf = config('Cache');
+        $cacheConf          = config('Cache');
         $cacheConf->handler = 'memcached';
-        $doctrine = new Doctrine($this->config, $cacheConf);
-        $cache = $doctrine->em->getConfiguration()->getQueryCache();
-        $key = 'test_doctrine_memcached_cache';
-        $value = ['foo' => 'bar', 'baz' => 123];
+        $doctrine           = new Doctrine($this->config, $cacheConf);
+        $cache              = $doctrine->em->getConfiguration()->getQueryCache();
+        $key                = 'test_doctrine_memcached_cache';
+        $value              = ['foo' => 'bar', 'baz' => 123];
         $cache->deleteItem($key);
         $cache->save($cache->getItem($key)->set($value));
         $item = $cache->getItem($key);
         $this->assertTrue($item->isHit(), 'El valor debería estar en caché');
-        $this->assertEquals($value, $item->get());
+        $this->assertSame($value, $item->get());
         $cache->deleteItem($key);
     }
 }

--- a/tests/DoctrineCacheRedisTest.php
+++ b/tests/DoctrineCacheRedisTest.php
@@ -4,37 +4,39 @@ declare(strict_types=1);
 
 namespace Tests;
 
+use Daycry\Doctrine\Doctrine;
 use Doctrine\ORM\EntityManager;
 use Psr\Cache\CacheItemPoolInterface;
-use Daycry\Doctrine\Doctrine;
-use Config\Cache;
 use Tests\Support\TestCase;
 
+/**
+ * @internal
+ */
 final class DoctrineCacheRedisTest extends TestCase
 {
     public function testDoctrineWithRedisCache()
     {
-        $cacheConf = config('Cache');
+        $cacheConf          = config('Cache');
         $cacheConf->handler = 'redis';
-        $doctrine = new Doctrine($this->config, $cacheConf);
+        $doctrine           = new Doctrine($this->config, $cacheConf);
         $this->assertInstanceOf(Doctrine::class, $doctrine);
         $this->assertInstanceOf(EntityManager::class, $doctrine->em);
     }
 
     public function testDoctrineRedisCachePersistsData()
     {
-        $cacheConf = config('Cache');
+        $cacheConf          = config('Cache');
         $cacheConf->handler = 'redis';
-        $doctrine = new Doctrine($this->config, $cacheConf);
-        $cache = $doctrine->em->getConfiguration()->getQueryCache();
-        $key = 'test_doctrine_redis_cache';
-        $value = ['foo' => 'bar', 'baz' => 123];
+        $doctrine           = new Doctrine($this->config, $cacheConf);
+        $cache              = $doctrine->em->getConfiguration()->getQueryCache();
+        $key                = 'test_doctrine_redis_cache';
+        $value              = ['foo' => 'bar', 'baz' => 123];
         $this->assertInstanceOf(CacheItemPoolInterface::class, $cache);
         $cache->deleteItem($key);
         $cache->save($cache->getItem($key)->set($value));
         $item = $cache->getItem($key);
         $this->assertTrue($item->isHit(), 'El valor debería estar en caché');
-        $this->assertEquals($value, $item->get());
+        $this->assertSame($value, $item->get());
         $cache->deleteItem($key);
     }
 }

--- a/tests/DoctrineCollectorCoverageTest.php
+++ b/tests/DoctrineCollectorCoverageTest.php
@@ -43,6 +43,43 @@ final class DoctrineCollectorCoverageTest extends TestCase
         $this->assertSame([], $collector->getQueries());
     }
 
+    public function testAddQueryEvictsOldestWhenMaxQueriesReached(): void
+    {
+        $collector = new DoctrineCollector();
+        $collector->setMaxQueries(2);
+
+        $collector->addQuery(['sql' => 'SELECT 1', 'params' => [], 'duration' => 0.0]);
+        $collector->addQuery(['sql' => 'SELECT 2', 'params' => [], 'duration' => 0.0]);
+        $collector->addQuery(['sql' => 'SELECT 3', 'params' => [], 'duration' => 0.0]);
+
+        $sqls = array_column($collector->getQueries(), 'sql');
+        $this->assertSame(['SELECT 2', 'SELECT 3'], $sqls, 'Oldest query must be dropped FIFO when the cap is reached.');
+    }
+
+    public function testSetMaxQueriesWithZeroDisablesTheCap(): void
+    {
+        $collector = new DoctrineCollector();
+        $collector->setMaxQueries(0);
+
+        for ($i = 0; $i < 5; $i++) {
+            $collector->addQuery(['sql' => 'SELECT ' . $i, 'params' => [], 'duration' => 0.0]);
+        }
+
+        $this->assertCount(5, $collector->getQueries(), 'Cap of 0 must keep every query.');
+    }
+
+    public function testSetMaxQueriesNormalisesNegativeToZero(): void
+    {
+        $collector = new DoctrineCollector();
+        $collector->setMaxQueries(-3);
+
+        for ($i = 0; $i < 3; $i++) {
+            $collector->addQuery(['sql' => 'SELECT ' . $i, 'params' => [], 'duration' => 0.0]);
+        }
+
+        $this->assertCount(3, $collector->getQueries());
+    }
+
     public function testIconReturnsPngDataUrl(): void
     {
         $collector = new DoctrineCollector();

--- a/tests/DoctrineCollectorCoverageTest.php
+++ b/tests/DoctrineCollectorCoverageTest.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Tests;
 
-use Tests\Support\TestCase;
 use Daycry\Doctrine\Debug\Toolbar\Collectors\DoctrineCollector;
 use Doctrine\ORM\Cache\Logging\StatisticsCacheLogger;
+use Tests\Support\TestCase;
 
 /**
  * Covers previously untested DoctrineCollector methods:
  * reset(), formatTimelineData() via getTimeline(), icon(), getData() SLC path.
+ *
+ * @internal
  */
 final class DoctrineCollectorCoverageTest extends TestCase
 {
@@ -52,8 +54,10 @@ final class DoctrineCollectorCoverageTest extends TestCase
 
     public function testFormatTimelineDataViaSubclass(): void
     {
-        $collector = new class extends DoctrineCollector {
-            /** @return array<int, array<string, mixed>> */
+        $collector = new class () extends DoctrineCollector {
+            /**
+             * @return array<int, array<string, mixed>>
+             */
             public function exposeFormatTimeline(): array
             {
                 return $this->formatTimelineData();
@@ -90,8 +94,10 @@ final class DoctrineCollectorCoverageTest extends TestCase
 
     public function testFormatTimelineDataWithMissingFields(): void
     {
-        $collector = new class extends DoctrineCollector {
-            /** @return array<int, array<string, mixed>> */
+        $collector = new class () extends DoctrineCollector {
+            /**
+             * @return array<int, array<string, mixed>>
+             */
             public function exposeFormatTimeline(): array
             {
                 return $this->formatTimelineData();

--- a/tests/DoctrineCollectorSlcNoQueriesTest.php
+++ b/tests/DoctrineCollectorSlcNoQueriesTest.php
@@ -7,6 +7,9 @@ use Daycry\Doctrine\Debug\Toolbar\Collectors\DoctrineCollector;
 use Doctrine\ORM\Cache\EntityCacheKey;
 use Doctrine\ORM\Cache\Logging\StatisticsCacheLogger;
 
+/**
+ * @internal
+ */
 final class DoctrineCollectorSlcNoQueriesTest extends CIUnitTestCase
 {
     private static function makeLogger(int $hits, int $misses, int $puts): StatisticsCacheLogger

--- a/tests/DoctrineCollectorSlcTest.php
+++ b/tests/DoctrineCollectorSlcTest.php
@@ -7,6 +7,9 @@ use Daycry\Doctrine\Debug\Toolbar\Collectors\DoctrineCollector;
 use Doctrine\ORM\Cache\EntityCacheKey;
 use Doctrine\ORM\Cache\Logging\StatisticsCacheLogger;
 
+/**
+ * @internal
+ */
 final class DoctrineCollectorSlcTest extends CIUnitTestCase
 {
     /**

--- a/tests/DoctrineCollectorTest.php
+++ b/tests/DoctrineCollectorTest.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Tests;
 
-use Tests\Support\TestCase;
 use Daycry\Doctrine\Debug\Toolbar\Collectors\DoctrineCollector;
+use Tests\Support\TestCase;
 
+/**
+ * @internal
+ */
 final class DoctrineCollectorTest extends TestCase
 {
     protected function setUp(): void
@@ -17,26 +20,26 @@ final class DoctrineCollectorTest extends TestCase
     public function testAddQueryAndGetQueries()
     {
         $collector = new DoctrineCollector();
-        $query = [
-            'sql' => 'SELECT * FROM users WHERE id = ?',
-            'params' => [1],
-            'duration' => 0.1234
+        $query     = [
+            'sql'      => 'SELECT * FROM users WHERE id = ?',
+            'params'   => [1],
+            'duration' => 0.1234,
         ];
         $collector->addQuery($query);
         $queries = $collector->getQueries();
         $this->assertNotEmpty($queries);
-        $this->assertEquals($query['sql'], $queries[0]['sql']);
-        $this->assertEquals($query['params'], $queries[0]['params']);
-        $this->assertEquals($query['duration'], $queries[0]['duration']);
+        $this->assertSame($query['sql'], $queries[0]['sql']);
+        $this->assertSame($query['params'], $queries[0]['params']);
+        $this->assertSame($query['duration'], $queries[0]['duration']);
     }
 
     public function testDisplayReturnsHtml()
     {
         $collector = new DoctrineCollector();
         $collector->addQuery([
-            'sql' => 'SELECT * FROM users',
-            'params' => [],
-            'duration' => 0.1
+            'sql'      => 'SELECT * FROM users',
+            'params'   => [],
+            'duration' => 0.1,
         ]);
         $html = $collector->display();
         $this->assertStringContainsString('<table>', $html);
@@ -48,9 +51,9 @@ final class DoctrineCollectorTest extends TestCase
         $collector = new DoctrineCollector();
         $this->assertTrue($collector->isEmpty());
         $collector->addQuery([
-            'sql' => 'SELECT 1',
-            'params' => [],
-            'duration' => 0.01
+            'sql'      => 'SELECT 1',
+            'params'   => [],
+            'duration' => 0.01,
         ]);
         $this->assertFalse($collector->isEmpty());
     }
@@ -61,9 +64,9 @@ final class DoctrineCollectorTest extends TestCase
         $this->assertSame('Doctrine', $collector->getTitle());
         $this->assertSame('', $collector->getTitleDetails());
         $collector->addQuery([
-            'sql' => 'SELECT 1',
-            'params' => [],
-            'duration' => 0.01
+            'sql'      => 'SELECT 1',
+            'params'   => [],
+            'duration' => 0.01,
         ]);
         $this->assertStringContainsString('query', $collector->getTitleDetails());
     }
@@ -71,9 +74,17 @@ final class DoctrineCollectorTest extends TestCase
     public function testDebugToolbarDisplayHighlightsKeywords()
     {
         $collector = new DoctrineCollector();
-        $sql = 'SELECT * FROM users WHERE id = 1';
-        $highlighted = $collector->debugToolbarDisplayPublic($sql);
-        $this->assertStringContainsString('<strong>', $highlighted);
+        $sql       = 'SELECT * FROM users WHERE id = 1';
+
+        // The highlighter is a protected method; verify via display() output.
+        $collector->addQuery([
+            'sql'      => $sql,
+            'params'   => [],
+            'duration' => 0.01,
+        ]);
+        $html = $collector->display();
+        $this->assertStringContainsString('<strong>', $html);
+        $this->assertStringContainsString('SELECT', $html);
     }
 
     public function testGetBadgeValue()
@@ -81,9 +92,9 @@ final class DoctrineCollectorTest extends TestCase
         $collector = new DoctrineCollector();
         $this->assertSame(0, $collector->getBadgeValue());
         $collector->addQuery([
-            'sql' => 'SELECT 1',
-            'params' => [],
-            'duration' => 0.01
+            'sql'      => 'SELECT 1',
+            'params'   => [],
+            'duration' => 0.01,
         ]);
         $this->assertSame(1, $collector->getBadgeValue());
     }
@@ -92,9 +103,9 @@ final class DoctrineCollectorTest extends TestCase
     {
         $collector = new DoctrineCollector();
         $collector->addQuery([
-            'sql' => 'SELECT 1',
-            'params' => [],
-            'duration' => 0.01
+            'sql'      => 'SELECT 1',
+            'params'   => [],
+            'duration' => 0.01,
         ]);
         $data = $collector->getData();
         $this->assertArrayHasKey('queries', $data);
@@ -104,7 +115,7 @@ final class DoctrineCollectorTest extends TestCase
     public function testDisplayWithNoQueries()
     {
         $collector = new DoctrineCollector();
-        $html = $collector->display();
+        $html      = $collector->display();
         $this->assertStringContainsString('No Doctrine queries executed', $html);
     }
 }

--- a/tests/DoctrineMiddlewareCoverageTest.php
+++ b/tests/DoctrineMiddlewareCoverageTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Tests;
 
-use Throwable;
-use Tests\Support\TestCase;
-use Tests\Support\Models\Entities\TestAttribute;
-use Daycry\Doctrine\Doctrine;
 use Daycry\Doctrine\Debug\Toolbar\Collectors\DoctrineCollector;
+use Daycry\Doctrine\Doctrine;
 use Doctrine\ORM\Tools\SchemaTool;
+use Tests\Support\Models\Entities\TestAttribute;
+use Tests\Support\TestCase;
+use Throwable;
 
 /**
  * Covers DoctrineQueryMiddleware Connection methods that require an active DB:
@@ -17,6 +17,8 @@ use Doctrine\ORM\Tools\SchemaTool;
  * getNativeConnection(), quote(), getServerVersion(), getExceptionConverter().
  *
  * All tests use SQLite :memory: — no external service required.
+ *
+ * @internal
  */
 final class DoctrineMiddlewareCoverageTest extends TestCase
 {
@@ -57,7 +59,7 @@ final class DoctrineMiddlewareCoverageTest extends TestCase
     {
         $tool = $this->createSchema();
 
-        $conn = $this->doctrine->em->getConnection();
+        $conn   = $this->doctrine->em->getConnection();
         $result = $conn->executeQuery('SELECT 1');
         $row    = $result->fetchOne();
 
@@ -76,7 +78,7 @@ final class DoctrineMiddlewareCoverageTest extends TestCase
         // Insert a row inside the transaction
         $conn->executeStatement(
             'INSERT INTO test (name, created_at) VALUES (?, ?)',
-            ['tx_test', '2026-01-01 00:00:00']
+            ['tx_test', '2026-01-01 00:00:00'],
         );
 
         $conn->commit();
@@ -96,7 +98,7 @@ final class DoctrineMiddlewareCoverageTest extends TestCase
 
         $conn->executeStatement(
             'INSERT INTO test (name, created_at) VALUES (?, ?)',
-            ['rollback_test', '2026-01-01 00:00:00']
+            ['rollback_test', '2026-01-01 00:00:00'],
         );
 
         $conn->rollBack();
@@ -111,14 +113,14 @@ final class DoctrineMiddlewareCoverageTest extends TestCase
     {
         $tool = $this->createSchema();
 
-        $conn          = $this->doctrine->em->getConnection();
-        $collector     = new DoctrineCollector();
+        $conn      = $this->doctrine->em->getConnection();
+        $collector = new DoctrineCollector();
         count($collector->getQueries());
 
         // executeStatement routes through exec() on the middleware Connection
         $affected = $conn->executeStatement(
             'INSERT INTO test (name, created_at) VALUES (?, ?)',
-            ['exec_test', '2026-01-01 00:00:00']
+            ['exec_test', '2026-01-01 00:00:00'],
         );
 
         $this->assertGreaterThanOrEqual(1, $affected);
@@ -133,7 +135,7 @@ final class DoctrineMiddlewareCoverageTest extends TestCase
         $conn = $this->doctrine->em->getConnection();
         $conn->executeStatement(
             'INSERT INTO test (name, created_at) VALUES (?, ?)',
-            ['insert_id_test', '2026-01-01 00:00:00']
+            ['insert_id_test', '2026-01-01 00:00:00'],
         );
 
         $id = $conn->lastInsertId();
@@ -156,7 +158,7 @@ final class DoctrineMiddlewareCoverageTest extends TestCase
         $conn   = $this->doctrine->em->getConnection();
         $quoted = $conn->quote("O'Reilly");
 
-        $this->assertStringContainsString("O", $quoted);
+        $this->assertStringContainsString('O', $quoted);
         $this->assertIsString($quoted);
     }
 

--- a/tests/DoctrineNullGuardsTest.php
+++ b/tests/DoctrineNullGuardsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests;
 
 use Daycry\Doctrine\Doctrine;
+use Doctrine\ORM\Cache\Logging\StatisticsCacheLogger;
 use ReflectionProperty;
 use RuntimeException;
 use Tests\Support\TestCase;
@@ -65,7 +66,7 @@ final class DoctrineNullGuardsTest extends TestCase
 
         $doctrine = new Doctrine($this->config, config('Cache'), 'tests');
 
-        $this->assertNull($doctrine->getSecondLevelCacheLogger());
+        $this->assertNotInstanceOf(StatisticsCacheLogger::class, $doctrine->getSecondLevelCacheLogger());
     }
 
     public function testGetSecondLevelCacheLoggerReturnsNullWhenSlcDisabled(): void
@@ -74,7 +75,7 @@ final class DoctrineNullGuardsTest extends TestCase
         $this->config->secondLevelCache = false;
         $doctrine                       = new Doctrine($this->config, config('Cache'), 'tests');
 
-        $this->assertNull($doctrine->getSecondLevelCacheLogger());
+        $this->assertNotInstanceOf(StatisticsCacheLogger::class, $doctrine->getSecondLevelCacheLogger());
     }
 
     public function testResetSecondLevelCacheStatisticsIsNoOpWhenLoggerMissing(): void
@@ -86,6 +87,6 @@ final class DoctrineNullGuardsTest extends TestCase
         // Must not throw even though there is no logger to reset.
         $doctrine->resetSecondLevelCacheStatistics();
 
-        $this->assertNull($doctrine->getSecondLevelCacheLogger());
+        $this->assertNotInstanceOf(StatisticsCacheLogger::class, $doctrine->getSecondLevelCacheLogger());
     }
 }

--- a/tests/DoctrineNullGuardsTest.php
+++ b/tests/DoctrineNullGuardsTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use Daycry\Doctrine\Doctrine;
+use ReflectionProperty;
+use RuntimeException;
+use Tests\Support\TestCase;
+
+/**
+ * Covers the `RuntimeException` paths added in PR #15:
+ *
+ *  - Doctrine::getEm() throws when $em is null.
+ *  - Doctrine::reOpen() goes through getEm() and therefore inherits the guard.
+ *  - Doctrine::getSecondLevelCacheLogger() returns null when the configuration
+ *    has no `StatisticsCacheLogger` attached (the `instanceof` false branch).
+ *
+ * @internal
+ */
+final class DoctrineNullGuardsTest extends TestCase
+{
+    private Doctrine $doctrine;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Use SQLite in-memory so the constructor succeeds without MySQL.
+        $db                    = config('Database');
+        $db->tests['DBDriver'] = 'SQLite3';
+        $db->tests['database'] = ':memory:';
+
+        $this->doctrine = new Doctrine($this->config, config('Cache'), 'tests');
+    }
+
+    public function testGetEmThrowsWhenEntityManagerIsNull(): void
+    {
+        // Force the public property to null without calling reOpen().
+        $emProp = new ReflectionProperty($this->doctrine, 'em');
+        $emProp->setValue($this->doctrine, null);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('EntityManager has not been initialized.');
+
+        $this->doctrine->getEm();
+    }
+
+    public function testReOpenThrowsWhenEntityManagerIsNull(): void
+    {
+        $emProp = new ReflectionProperty($this->doctrine, 'em');
+        $emProp->setValue($this->doctrine, null);
+
+        $this->expectException(RuntimeException::class);
+
+        $this->doctrine->reOpen();
+    }
+
+    public function testGetSecondLevelCacheLoggerReturnsNullWhenStatsDisabled(): void
+    {
+        // SLC enabled but statistics disabled → no StatisticsCacheLogger attached.
+        $this->config->secondLevelCache           = true;
+        $this->config->secondLevelCacheStatistics = false;
+
+        $doctrine = new Doctrine($this->config, config('Cache'), 'tests');
+
+        $this->assertNull($doctrine->getSecondLevelCacheLogger());
+    }
+
+    public function testGetSecondLevelCacheLoggerReturnsNullWhenSlcDisabled(): void
+    {
+        // SLC fully disabled → getConfiguration()->getSecondLevelCacheConfiguration() is null.
+        $this->config->secondLevelCache = false;
+        $doctrine                       = new Doctrine($this->config, config('Cache'), 'tests');
+
+        $this->assertNull($doctrine->getSecondLevelCacheLogger());
+    }
+
+    public function testResetSecondLevelCacheStatisticsIsNoOpWhenLoggerMissing(): void
+    {
+        $this->config->secondLevelCache           = true;
+        $this->config->secondLevelCacheStatistics = false;
+        $doctrine                                 = new Doctrine($this->config, config('Cache'), 'tests');
+
+        // Must not throw even though there is no logger to reset.
+        $doctrine->resetSecondLevelCacheStatistics();
+
+        $this->assertNull($doctrine->getSecondLevelCacheLogger());
+    }
+}

--- a/tests/DoctrineQueryTest.php
+++ b/tests/DoctrineQueryTest.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Tests;
 
-use Tests\Support\Models\Entities\TestAttribute;
 use CodeIgniter\Test\DatabaseTestTrait;
-use Tests\Support\Database\Seeds\TestSeeder;
 use Daycry\Doctrine\Doctrine;
-use Daycry\Doctrine\Config\Doctrine as DoctrineConfig;
+use Tests\Support\Database\Seeds\TestSeeder;
+use Tests\Support\Models\Entities\TestAttribute;
 use Tests\Support\TestCase;
 
+/**
+ * @internal
+ */
 final class DoctrineQueryTest extends TestCase
 {
     use DatabaseTestTrait;
@@ -18,8 +20,8 @@ final class DoctrineQueryTest extends TestCase
     protected $migrate     = true;
     protected $migrateOnce = false;
     protected $refresh     = true;
-    protected $seedOnce = false;
-    protected $seed = TestSeeder::class;
+    protected $seedOnce    = false;
+    protected $seed        = TestSeeder::class;
 
     protected function setUp(): void
     {
@@ -31,9 +33,9 @@ final class DoctrineQueryTest extends TestCase
     public function testQueryAttribute()
     {
         $this->config->metadataConfigurationMethod = 'attribute';
-        $doctrine = new Doctrine($this->config);
+        $doctrine                                  = new Doctrine($this->config);
 
-        $data = $doctrine->em->getRepository("Tests\Support\Models\Entities\TestAttribute")->findOneBy([ 'id' => 1 ]);
+        $data = $doctrine->em->getRepository('Tests\\Support\\Models\\Entities\\TestAttribute')->findOneBy(['id' => 1]);
         $this->assertInstanceOf(TestAttribute::class, $data);
 
         $this->assertSame(1, $data->getId());

--- a/tests/DoctrineSLCCoverageTest.php
+++ b/tests/DoctrineSLCCoverageTest.php
@@ -5,20 +5,23 @@ declare(strict_types=1);
 namespace Tests;
 
 use CodeIgniter\Exceptions\ConfigException;
-use Tests\Support\TestCase;
 use Daycry\Doctrine\Doctrine;
-use Daycry\Doctrine\Config\Doctrine as DoctrineConfig;
 use Doctrine\ORM\Cache\Logging\StatisticsCacheLogger;
+use Tests\Support\TestCase;
 
 /**
  * Covers previously untested Doctrine methods:
  * - getSecondLevelCacheLogger() — null, non-stats-logger, and stats-logger branches
  * - resetSecondLevelCacheStatistics() — null-logger and clearStats branches
  * - createSecondLevelCachePool() — file and dummy(default) branches
+ *
+ * @internal
  */
 final class DoctrineSLCCoverageTest extends TestCase
 {
-    /** @var string Original cache handler to restore after each test */
+    /**
+     * @var string Original cache handler to restore after each test
+     */
     private string $originalCacheHandler = 'file';
 
     protected function setUp(): void
@@ -144,7 +147,7 @@ final class DoctrineSLCCoverageTest extends TestCase
         $cacheConfig->prefix  = 'ci_';
 
         // Use sys_get_temp_dir() so the path is writable in CI
-        $tmpDir                     = sys_get_temp_dir();
+        $tmpDir                         = sys_get_temp_dir();
         $cacheConfig->file['storePath'] = $tmpDir;
 
         $doctrine = new Doctrine($this->config, $cacheConfig, 'tests');

--- a/tests/DoctrineSlcResetTest.php
+++ b/tests/DoctrineSlcResetTest.php
@@ -4,25 +4,28 @@ declare(strict_types=1);
 
 namespace Tests;
 
-use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\Response;
-use CodeIgniter\HTTP\SiteURI;
-use CodeIgniter\HTTP\UserAgent;
-use Tests\Support\TestCase;
+use CodeIgniter\HTTP\ResponseInterface;
+use Daycry\Doctrine\Config\Services;
 use Daycry\Doctrine\Debug\Filters\DoctrineSlcReset;
+use Daycry\Doctrine\Doctrine;
+use Doctrine\ORM\Cache\EntityCacheKey;
+use stdClass;
+use Tests\Support\TestCase;
 
 /**
- * Covers DoctrineSlcReset::before() and DoctrineSlcReset::after()
+ * Covers DoctrineSlcReset::before() and DoctrineSlcReset::after().
+ *
+ * The filter is intentionally tolerant: it must never throw, even when the
+ * Doctrine service is not bootstrapped or the SLC logger is not configured.
+ * When the logger is available, before() must reset its counters.
+ *
+ * @internal
  */
 final class DoctrineSlcResetTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-    }
-
-    public function testBeforeReturnsNull(): void
+    public function testBeforeReturnsNullAndDoesNotThrowWhenServiceUnavailable(): void
     {
         $filter  = new DoctrineSlcReset();
         $request = $this->createStub(IncomingRequest::class);
@@ -41,5 +44,43 @@ final class DoctrineSlcResetTest extends TestCase
         $result = $filter->after($request, $response);
 
         $this->assertNotInstanceOf(ResponseInterface::class, $result);
+        $this->assertNull($result);
+    }
+
+    public function testBeforeResetsSlcStatisticsWhenLoggerPresent(): void
+    {
+        // Use SQLite in-memory so tests don't require a live database connection.
+        $db                    = config('Database');
+        $db->tests['DBDriver'] = 'SQLite3';
+        $db->tests['database'] = ':memory:';
+
+        $this->config->secondLevelCache           = true;
+        $this->config->secondLevelCacheStatistics = true;
+
+        $doctrine = new Doctrine($this->config, config('Cache'), 'tests');
+        $logger   = $doctrine->getSecondLevelCacheLogger();
+
+        if ($logger === null) {
+            $this->markTestSkipped('SLC stats logger not configured in this environment.');
+        }
+
+        $key = new EntityCacheKey(stdClass::class, ['id' => 1]);
+        $logger->entityCacheHit('test', $key);
+        $logger->entityCacheMiss('test', $key);
+        $logger->entityCachePut('test', $key);
+
+        $this->assertSame(1, $logger->getHitCount());
+        $this->assertSame(1, $logger->getMissCount());
+        $this->assertSame(1, $logger->getPutCount());
+
+        // Inject the doctrine service so the filter resets the same logger.
+        Services::injectMock('doctrine_default', $doctrine);
+
+        $filter = new DoctrineSlcReset();
+        $filter->before($this->createStub(IncomingRequest::class));
+
+        $this->assertSame(0, $logger->getHitCount());
+        $this->assertSame(0, $logger->getMissCount());
+        $this->assertSame(0, $logger->getPutCount());
     }
 }

--- a/tests/DoctrineTest.php
+++ b/tests/DoctrineTest.php
@@ -4,15 +4,17 @@ declare(strict_types=1);
 
 namespace Tests;
 
-use Config\Services;
 use CodeIgniter\Test\DatabaseTestTrait;
-use Tests\Support\Database\Seeds\TestSeeder;
-use Doctrine\ORM\EntityManager;
-use Daycry\Doctrine\Doctrine;
-use Daycry\Doctrine\Config\Doctrine as DoctrineConfig;
-use Tests\Support\TestCase;
 use Config\Cache;
+use Config\Services;
+use Daycry\Doctrine\Doctrine;
+use Doctrine\ORM\EntityManager;
+use Tests\Support\Database\Seeds\TestSeeder;
+use Tests\Support\TestCase;
 
+/**
+ * @internal
+ */
 final class DoctrineTest extends TestCase
 {
     use DatabaseTestTrait;
@@ -20,8 +22,8 @@ final class DoctrineTest extends TestCase
     protected $migrate     = true;
     protected $migrateOnce = false;
     protected $refresh     = true;
-    protected $seedOnce = false;
-    protected $seed = TestSeeder::class;
+    protected $seedOnce    = false;
+    protected $seed        = TestSeeder::class;
 
     protected function setUp(): void
     {
@@ -59,7 +61,7 @@ final class DoctrineTest extends TestCase
     public function testInstanceDoctrineRedis()
     {
         /** @var Cache $cacheConf */
-        $cacheConf = config('Cache');
+        $cacheConf          = config('Cache');
         $cacheConf->handler = 'redis';
 
         $cache = Services::cache($cacheConf);
@@ -75,7 +77,7 @@ final class DoctrineTest extends TestCase
     public function testInstanceDoctrineFile()
     {
         /** @var Cache $cacheConf */
-        $cacheConf = config('Cache');
+        $cacheConf          = config('Cache');
         $cacheConf->handler = 'file';
 
         $doctrine = new Doctrine($this->config, $cacheConf);
@@ -86,12 +88,12 @@ final class DoctrineTest extends TestCase
 
     public function testInstanceDoctrineMemcached()
     {
-        if (!extension_loaded('memcached')) {
+        if (! extension_loaded('memcached')) {
             $this->markTestSkipped('La extensión memcached no está habilitada.');
         }
-        
+
         /** @var Cache $cacheConf */
-        $cacheConf = config('Cache');
+        $cacheConf          = config('Cache');
         $cacheConf->handler = 'memcached';
 
         $doctrine = new Doctrine($this->config, $cacheConf);
@@ -103,7 +105,7 @@ final class DoctrineTest extends TestCase
     public function testInstanceDoctrineArray()
     {
         /** @var Cache $cacheConf */
-        $cacheConf = config('Cache');
+        $cacheConf          = config('Cache');
         $cacheConf->handler = 'dummy';
 
         $doctrine = new Doctrine($this->config, $cacheConf);
@@ -126,23 +128,23 @@ final class DoctrineTest extends TestCase
     {
         $dbConfig = config('Database');
         // Crea un objeto temporal con el grupo custom
-        $customConfig = clone $dbConfig;
+        $customConfig        = clone $dbConfig;
         $customConfig->tests = $dbConfig->tests;
-        $doctrine = new Doctrine($this->config, null, 'tests');
+        $doctrine            = new Doctrine($this->config, null, 'tests');
         $this->assertInstanceOf(Doctrine::class, $doctrine);
         $this->assertInstanceOf(EntityManager::class, $doctrine->em);
     }
 
     public function testDoctrineWithSSLOptions()
     {
-        $dbConfig = $this->getMysqlConfig();
+        $dbConfig                   = $this->getMysqlConfig();
         $dbConfig->tests['sslmode'] = 'require';
         $dbConfig->tests['sslcert'] = '/path/to/cert.pem';
-        $dbConfig->tests['sslkey'] = '/path/to/key.pem';
-        $dbConfig->tests['sslca'] = '/path/to/ca.pem';
-        $doctrine = new Doctrine($this->config, null, 'tests');
-        $options = $doctrine->em->getConnection()->getParams();
-        if (!isset($options['sslmode']) || !isset($options['sslcert']) || !isset($options['sslkey']) || !isset($options['sslca'])) {
+        $dbConfig->tests['sslkey']  = '/path/to/key.pem';
+        $dbConfig->tests['sslca']   = '/path/to/ca.pem';
+        $doctrine                   = new Doctrine($this->config, null, 'tests');
+        $options                    = $doctrine->em->getConnection()->getParams();
+        if (! isset($options['sslmode']) || ! isset($options['sslcert']) || ! isset($options['sslkey']) || ! isset($options['sslca'])) {
             $this->markTestSkipped('SSL options not available in this environment/config.');
         }
         $this->assertSame('require', $options['sslmode']);
@@ -153,14 +155,14 @@ final class DoctrineTest extends TestCase
 
     public function testDoctrineWithCustomOptions()
     {
-        $dbConfig = $this->getMysqlConfig();
+        $dbConfig                   = $this->getMysqlConfig();
         $dbConfig->tests['options'] = [
             'foo' => 'bar',
-            'baz' => 123
+            'baz' => 123,
         ];
         $doctrine = new Doctrine($this->config, null, 'tests');
-        $options = $doctrine->em->getConnection()->getParams();
-        if (!isset($options['foo']) || !isset($options['baz'])) {
+        $options  = $doctrine->em->getConnection()->getParams();
+        if (! isset($options['foo']) || ! isset($options['baz'])) {
             $this->markTestSkipped('Custom options not available in this environment/config.');
         }
         $this->assertSame('bar', $options['foo']);

--- a/tests/GetFromCacheOrQueryTest.php
+++ b/tests/GetFromCacheOrQueryTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use Daycry\Doctrine\Config\Services;
+use Daycry\Doctrine\Doctrine;
+use Tests\Support\TestCase;
+
+use function Daycry\Doctrine\Helpers\getFromCacheOrQuery;
+
+/**
+ * @internal
+ */
+final class GetFromCacheOrQueryTest extends TestCase
+{
+    private Doctrine $doctrine;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Use SQLite3 in-memory so tests don't depend on a running MySQL instance.
+        $db                    = config('Database');
+        $db->tests['DBDriver'] = 'SQLite3';
+        $db->tests['database'] = ':memory:';
+
+        $this->config->resultsCache = true;
+        $this->doctrine             = new Doctrine($this->config, config('Cache'), 'tests');
+        Services::injectMock('doctrine_default', $this->doctrine);
+    }
+
+    protected function tearDown(): void
+    {
+        // Clear the result cache pool between tests
+        $pool = $this->doctrine->em?->getConfiguration()->getResultCache();
+        $pool?->clear();
+
+        parent::tearDown();
+    }
+
+    public function testQueryRunsOnCacheMiss(): void
+    {
+        $calls   = 0;
+        $queryFn = static function () use (&$calls) {
+            $calls++;
+
+            return ['hello', 'world'];
+        };
+
+        $result = getFromCacheOrQuery('test_miss_' . uniqid(), 60, $queryFn);
+
+        $this->assertSame(['hello', 'world'], $result);
+        $this->assertSame(1, $calls);
+    }
+
+    public function testQueryNotCalledOnCacheHit(): void
+    {
+        $key     = 'test_hit_' . uniqid();
+        $calls   = 0;
+        $queryFn = static function () use (&$calls) {
+            $calls++;
+
+            return 'computed';
+        };
+
+        $first  = getFromCacheOrQuery($key, 60, $queryFn);
+        $second = getFromCacheOrQuery($key, 60, $queryFn);
+
+        $this->assertSame('computed', $first);
+        $this->assertSame('computed', $second);
+        $this->assertSame(1, $calls, 'Second call should hit the cache and skip the closure');
+    }
+
+    public function testFallsBackToQueryWhenResultCacheDisabled(): void
+    {
+        // Recreate Doctrine with results cache disabled
+        $this->config->resultsCache = false;
+        $doctrine                   = new Doctrine($this->config, config('Cache'), 'tests');
+        Services::injectMock('doctrine_default', $doctrine);
+
+        $calls   = 0;
+        $queryFn = static function () use (&$calls) {
+            $calls++;
+
+            return 'always-fresh';
+        };
+
+        $first  = getFromCacheOrQuery('test_nocache_' . uniqid(), 60, $queryFn);
+        $second = getFromCacheOrQuery('test_nocache_' . uniqid(), 60, $queryFn);
+
+        $this->assertSame('always-fresh', $first);
+        $this->assertSame('always-fresh', $second);
+        $this->assertSame(2, $calls);
+    }
+
+    public function testTtlZeroPersistsWithoutExpiration(): void
+    {
+        $key     = 'test_ttl0_' . uniqid();
+        $calls   = 0;
+        $queryFn = static function () use (&$calls) {
+            $calls++;
+
+            return 42;
+        };
+
+        $first  = getFromCacheOrQuery($key, 0, $queryFn);
+        $second = getFromCacheOrQuery($key, 0, $queryFn);
+
+        $this->assertSame(42, $first);
+        $this->assertSame(42, $second);
+        $this->assertSame(1, $calls);
+    }
+}

--- a/tests/Libraries/InitializesNativeClientTest.php
+++ b/tests/Libraries/InitializesNativeClientTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Libraries;
+
+use CodeIgniter\Cache\Exceptions\CacheException;
+use Daycry\Doctrine\Libraries\InitializesNativeClient;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * Covers the two error paths in `InitializesNativeClient::bootClient()`:
+ *
+ *  - Required PHP extension is not loaded → CacheException with extension name.
+ *  - Underlying initialize() throws → CacheException wrapping the original.
+ *
+ * @internal
+ */
+final class InitializesNativeClientTest extends TestCase
+{
+    public function testBootClientThrowsWhenExtensionMissing(): void
+    {
+        $fixture = new class () {
+            use InitializesNativeClient;
+
+            public function initialize(): void
+            {
+                // never reached when ext is missing
+            }
+
+            public function trigger(string $extension, string $driver): void
+            {
+                $this->bootClient($extension, $driver);
+            }
+        };
+
+        $this->expectException(CacheException::class);
+        $this->expectExceptionMessageMatches('/extension not loaded/i');
+
+        $fixture->trigger('__definitely_not_a_real_extension__', 'FakeDriver');
+    }
+
+    public function testBootClientWrapsInitializationException(): void
+    {
+        $fixture = new class () {
+            use InitializesNativeClient;
+
+            public function initialize(): void
+            {
+                throw new RuntimeException('boom');
+            }
+
+            public function trigger(string $extension, string $driver): void
+            {
+                $this->bootClient($extension, $driver);
+            }
+        };
+
+        try {
+            // `json` is part of PHP core, so the extension check passes and
+            // the test reaches the try/catch branch.
+            $fixture->trigger('json', 'FakeDriver');
+            $this->fail('Expected CacheException was not thrown.');
+        } catch (CacheException $e) {
+            $this->assertStringContainsString('Failed to connect to FakeDriver', $e->getMessage());
+            $this->assertStringContainsString('boom', $e->getMessage());
+
+            $previous = $e->getPrevious();
+            $this->assertInstanceOf(RuntimeException::class, $previous);
+            $this->assertSame('boom', $previous->getMessage());
+        }
+    }
+}

--- a/tests/Libraries/InitializesNativeClientTest.php
+++ b/tests/Libraries/InitializesNativeClientTest.php
@@ -46,7 +46,7 @@ final class InitializesNativeClientTest extends TestCase
         $fixture = new class () {
             use InitializesNativeClient;
 
-            public function initialize(): void
+            public function initialize(): never
             {
                 throw new RuntimeException('boom');
             }

--- a/tests/SecondLevelCacheTest.php
+++ b/tests/SecondLevelCacheTest.php
@@ -2,29 +2,31 @@
 
 declare(strict_types=1);
 
-use Doctrine\ORM\Cache\CacheConfiguration;
-
 use CodeIgniter\Test\CIUnitTestCase;
 use Daycry\Doctrine\Config\Doctrine as DoctrineConfig;
 use Daycry\Doctrine\Doctrine;
-use Tests\Support\Models\Entities\CacheableProduct;
+use Doctrine\ORM\Cache\CacheConfiguration;
 use Doctrine\ORM\Tools\SchemaTool;
+use Tests\Support\Models\Entities\CacheableProduct;
 
+/**
+ * @internal
+ */
 final class SecondLevelCacheTest extends CIUnitTestCase
 {
     public function testSecondLevelCacheConfigurationIsApplied()
     {
         // Force SQLite3 in-memory for tests
-        $db = config('Database');
+        $db                    = config('Database');
         $db->tests['DBDriver'] = 'SQLite3';
         $db->tests['database'] = ':memory:';
 
-        $config = new DoctrineConfig();
-        $config->entities = [__DIR__ . '/_support/Models/Entities'];
+        $config                   = new DoctrineConfig();
+        $config->entities         = [__DIR__ . '/_support/Models/Entities'];
         $config->secondLevelCache = true;
 
         $doctrine = new Doctrine($config, config('Cache'), 'tests');
-        $em = $doctrine->em;
+        $em       = $doctrine->em;
 
         $this->assertTrue($em->getConfiguration()->isSecondLevelCacheEnabled());
         $this->assertInstanceOf(CacheConfiguration::class, $em->getConfiguration()->getSecondLevelCacheConfiguration());
@@ -33,23 +35,24 @@ final class SecondLevelCacheTest extends CIUnitTestCase
     public function testPersistAndFetchCacheableEntityWithoutErrors()
     {
         // Force SQLite3 in-memory for tests
-        $db = config('Database');
+        $db                    = config('Database');
         $db->tests['DBDriver'] = 'SQLite3';
         $db->tests['database'] = ':memory:';
 
-        $config = new DoctrineConfig();
-        $config->entities = [__DIR__ . '/_support/Models/Entities'];
+        $config                   = new DoctrineConfig();
+        $config->entities         = [__DIR__ . '/_support/Models/Entities'];
         $config->secondLevelCache = true;
 
         $doctrine = new Doctrine($config, config('Cache'), 'tests');
-        $em = $doctrine->em;
+        $em       = $doctrine->em;
 
         // Skip on SQLite memory DB if schema not available
         // Minimal check: ensure EntityManager works and operations do not error out
         $product = new CacheableProduct('Sample');
         // Create schema for the entity
         $metadata = $em->getClassMetadata(CacheableProduct::class);
-        $tool = new SchemaTool($em);
+        $tool     = new SchemaTool($em);
+
         try {
             $tool->createSchema([$metadata]);
         } catch (Throwable $e) {
@@ -71,7 +74,7 @@ final class SecondLevelCacheTest extends CIUnitTestCase
         // Cleanup schema
         try {
             $tool->dropSchema([$metadata]);
-        } catch (Throwable $e) {
+        } catch (Throwable) {
             // ignore
         }
     }
@@ -79,17 +82,17 @@ final class SecondLevelCacheTest extends CIUnitTestCase
     public function testSecondLevelCacheNoExpiryTtlZero()
     {
         // Force SQLite3 in-memory for tests
-        $db = config('Database');
+        $db                    = config('Database');
         $db->tests['DBDriver'] = 'SQLite3';
         $db->tests['database'] = ':memory:';
 
-        $config = new DoctrineConfig();
-        $config->entities = [__DIR__ . '/_support/Models/Entities'];
-        $config->secondLevelCache = true;
+        $config                      = new DoctrineConfig();
+        $config->entities            = [__DIR__ . '/_support/Models/Entities'];
+        $config->secondLevelCache    = true;
         $config->secondLevelCacheTtl = 0; // no expiration
 
         $doctrine = new Doctrine($config, config('Cache'), 'tests');
-        $em = $doctrine->em;
+        $em       = $doctrine->em;
 
         $this->assertTrue($em->getConfiguration()->isSecondLevelCacheEnabled());
         $slc = $em->getConfiguration()->getSecondLevelCacheConfiguration();

--- a/tests/ServicesTest.php
+++ b/tests/ServicesTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use Daycry\Doctrine\Config\Services;
+use Daycry\Doctrine\Doctrine;
+use Tests\Support\TestCase;
+
+/**
+ * @internal
+ */
+final class ServicesTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Avoid touching MySQL: use SQLite in-memory.
+        $db                    = config('Database');
+        $db->tests['DBDriver'] = 'SQLite3';
+        $db->tests['database'] = ':memory:';
+    }
+
+    public function testDoctrineServiceReturnsSharedInstance(): void
+    {
+        $a = Services::doctrine(true, 'tests');
+        $b = Services::doctrine(true, 'tests');
+
+        $this->assertInstanceOf(Doctrine::class, $a);
+        $this->assertSame($a, $b, 'Shared mode should return the same instance for the same group.');
+    }
+
+    public function testDoctrineServiceUnsharedReturnsFreshInstance(): void
+    {
+        $a = Services::doctrine(false, 'tests');
+        $b = Services::doctrine(false, 'tests');
+
+        $this->assertInstanceOf(Doctrine::class, $a);
+        $this->assertNotSame($a, $b, 'Unshared mode should always return a fresh instance.');
+    }
+
+    public function testResetDoctrineDropsCachedInstance(): void
+    {
+        $a = Services::doctrine(true, 'tests');
+        Services::resetDoctrine('tests');
+        $b = Services::doctrine(true, 'tests');
+
+        $this->assertNotSame($a, $b, 'After reset, a new shared instance must be created.');
+    }
+
+    public function testDoctrineCollectorReturnsSharedInstance(): void
+    {
+        $a = Services::doctrineCollector();
+        $b = Services::doctrineCollector();
+
+        $this->assertSame($a, $b);
+    }
+
+    public function testDoctrineCollectorUnsharedReturnsFresh(): void
+    {
+        $a = Services::doctrineCollector(false);
+        $b = Services::doctrineCollector(false);
+
+        $this->assertNotSame($a, $b);
+    }
+}

--- a/tests/_support/Database/Migrations/2022-08-09-000001_create_table.php
+++ b/tests/_support/Database/Migrations/2022-08-09-000001_create_table.php
@@ -5,18 +5,21 @@ namespace Tests\Support\Database\Migrations;
 use CodeIgniter\Database\Migration;
 use CodeIgniter\Database\RawSql;
 
-class CreateTableTest extends Migration
+/**
+ * @internal
+ */
+final class CreateTableTest extends Migration
 {
     protected $DBGroup = 'tests';
 
     public function up()
     {
         $this->forge->addField([
-            'id'                    => ['type' => 'int', 'constraint' => 11, 'unsigned' => true, 'auto_increment' => true],
-            'name'            => ['type' => 'varchar', 'constraint' => 255, 'null' => true, 'default' => null],
-            'created_at'     => ['type' => 'datetime', 'null' => false, 'default' => new RawSql('CURRENT_TIMESTAMP')],
-            'updated_at'     => ['type' => 'datetime', 'null' => true,'default' => null],
-            'deleted_at'     => ['type' => 'datetime', 'null' => true, 'default' => null]
+            'id'         => ['type' => 'int', 'constraint' => 11, 'unsigned' => true, 'auto_increment' => true],
+            'name'       => ['type' => 'varchar', 'constraint' => 255, 'null' => true, 'default' => null],
+            'created_at' => ['type' => 'datetime', 'null' => false, 'default' => new RawSql('CURRENT_TIMESTAMP')],
+            'updated_at' => ['type' => 'datetime', 'null' => true, 'default' => null],
+            'deleted_at' => ['type' => 'datetime', 'null' => true, 'default' => null],
         ]);
 
         $this->forge->addKey('id', true);

--- a/tests/_support/Database/Seeds/TestSeeder.php
+++ b/tests/_support/Database/Seeds/TestSeeder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Support\Database\Seeds;
 
 use CodeIgniter\Database\Seeder;
@@ -8,16 +10,13 @@ class TestSeeder extends Seeder
 {
     public function run()
     {
-        $petition = [
-            [
-                'name' => 'name1'
-            ],
-            [
-                'name' => 'name2'
-            ]
+        $rows = [
+            ['name' => 'name1'],
+            ['name' => 'name2'],
         ];
 
-        // Using Query Builder
-        $this->db->table('test')->insertBatch($petition);
+        // Idempotent: clear before insert so re-running the seeder does not violate UNIQUE(name).
+        $this->db->table('test')->truncate();
+        $this->db->table('test')->insertBatch($rows);
     }
 }

--- a/tests/_support/Models/Entities/CacheableProduct.php
+++ b/tests/_support/Models/Entities/CacheableProduct.php
@@ -4,22 +4,20 @@ namespace Tests\Support\Models\Entities;
 
 use Doctrine\ORM\Mapping as ORM;
 
+#[ORM\Cache(usage: 'READ_ONLY', region: 'default_region')]
 #[ORM\Entity]
 #[ORM\Table(name: 'cacheable_products')]
-#[ORM\Cache(usage: 'READ_ONLY', region: 'default_region')]
 class CacheableProduct
 {
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
+    #[ORM\Id]
     private ?int $id = null;
 
-    #[ORM\Column(length: 120)]
-    private string $name;
-
-    public function __construct(string $name)
-    {
-        $this->name = $name;
+    public function __construct(
+        #[ORM\Column(length: 120)]
+        private string $name,
+    ) {
     }
 
     public function getId(): ?int

--- a/tests/_support/Models/Entities/TestAttribute.php
+++ b/tests/_support/Models/Entities/TestAttribute.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\UniqueConstraint(name: 'name', columns: ['name'])]
 class TestAttribute
 {
-    #[ ORM\Column(name: 'id', type: 'integer', nullable: false), ORM\GeneratedValue(strategy: 'IDENTITY'),ORM\Id]
+    #[ORM\Column(name: 'id', type: 'integer', nullable: false), ORM\GeneratedValue(strategy: 'IDENTITY'),ORM\Id]
     private ?int $id = null;
 
     #[ORM\Column(name: 'name', type: 'string', nullable: false)]

--- a/tests/_support/Models/Entities/TestAttribute.php
+++ b/tests/_support/Models/Entities/TestAttribute.php
@@ -6,24 +6,24 @@ use DateTime;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity, ORM\HasLifecycleCallbacks]
+#[ORM\Index(name: 'deleted_at', columns: ['deleted_at'])]
 #[ORM\Table(name: 'test')]
-#[ORM\UniqueConstraint(name: "name", columns: ["name"])]
-#[ORM\Index(name: "deleted_at", columns: ["deleted_at"])]
+#[ORM\UniqueConstraint(name: 'name', columns: ['name'])]
 class TestAttribute
 {
-    #[ORM\Id, ORM\Column(name: "id", type: "integer", nullable: false), ORM\GeneratedValue(strategy: "IDENTITY")]
+    #[ ORM\Column(name: 'id', type: 'integer', nullable: false), ORM\GeneratedValue(strategy: 'IDENTITY'),ORM\Id]
     private ?int $id = null;
 
-    #[ORM\Column(name: "name", type: "string", nullable: false)]
+    #[ORM\Column(name: 'name', type: 'string', nullable: false)]
     private string $name = '';
 
-    #[ORM\Column(name: "created_at", type: "datetime", nullable: false, options: ["default" => "CURRENT_TIMESTAMP"])]
+    #[ORM\Column(name: 'created_at', type: 'datetime', nullable: false, options: ['default' => 'CURRENT_TIMESTAMP'])]
     private ?DateTime $createdAt = null;
 
-    #[ORM\Column(name: "updated_at", type: "datetime", nullable: true)]
+    #[ORM\Column(name: 'updated_at', type: 'datetime', nullable: true)]
     private ?DateTime $updatedAt = null;
 
-    #[ORM\Column(name: "deleted_at", type: "datetime", nullable: true)]
+    #[ORM\Column(name: 'deleted_at', type: 'datetime', nullable: true)]
     private ?DateTime $deletedAt = null;
 
     #[ORM\PrePersist]

--- a/tests/_support/TestCase.php
+++ b/tests/_support/TestCase.php
@@ -6,12 +6,12 @@ namespace Tests\Support;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Database;
-use Daycry\Doctrine\Config\Doctrine;
 use Daycry\Doctrine\Config\Doctrine as DoctrineConfig;
 
 abstract class TestCase extends CIUnitTestCase
 {
     protected DoctrineConfig $config;
+
     /**
      * Sets up the ArrayHandler for faster & easier tests.
      */
@@ -19,15 +19,15 @@ abstract class TestCase extends CIUnitTestCase
     {
         parent::setUp();
 
-        $this->config = config('Doctrine');
+        $this->config           = config('Doctrine');
         $this->config->entities = [SUPPORTPATH . 'Models/Entities'];
-        $this->config->proxies = SUPPORTPATH . 'Models/Proxies';
+        $this->config->proxies  = SUPPORTPATH . 'Models/Proxies';
     }
 
     private function _getDatabaseConfig(): Database
     {
-        /** @var Database $config*/
-        $config = config('Database');
+        /** @var Database $config */
+        $config                    = config('Database');
         $config->tests['database'] = 'doctrine_tests';
         $config->tests['hostname'] = '127.0.0.1';
         $config->tests['username'] = 'root';
@@ -39,24 +39,24 @@ abstract class TestCase extends CIUnitTestCase
 
     protected function getSQLite3Config(bool $memory = true): Database
     {
-        $config = $this->_getDatabaseConfig();
+        $config                    = $this->_getDatabaseConfig();
         $config->tests['DBDriver'] = 'SQLite3';
         $config->tests['database'] = $memory ? ':memory:' : SUPPORTPATH . 'db.sqlite';
+
         return $config;
     }
 
     protected function getSQLite3DSNConfig(bool $memory = true): Database
     {
-        $config = $this->_getDatabaseConfig();
+        $config               = $this->_getDatabaseConfig();
         $config->tests['DSN'] = $memory ? 'SQLite3:///:memory:' : 'SQLite3:' . SUPPORTPATH . 'db.sqlite';
 
         return $config;
     }
 
-
     protected function getMysqlConfig(): Database
     {
-        $config = $this->_getDatabaseConfig();
+        $config                    = $this->_getDatabaseConfig();
         $config->tests['DBDriver'] = 'MySQLi';
 
         return $config;
@@ -64,7 +64,7 @@ abstract class TestCase extends CIUnitTestCase
 
     protected function getMysqlDSNConfig(): Database
     {
-        $config = $this->_getDatabaseConfig();
+        $config               = $this->_getDatabaseConfig();
         $config->tests['DSN'] = 'MySQLi://root:@127.0.0.1:3306/doctrine_tests';
 
         return $config;


### PR DESCRIPTION
## Summary

  Outcome of an exhaustive audit of the package against
  its current code.
  The branch ships **9 themed commits** covering
  critical bug fixes, code
  refactors, test additions and a complete documentation
   overhaul.
  **No breaking changes for users on the documented
  API**; one internal
  helper (`Doctrine::convertDbConfigPdo()`) and one
  test-only escape hatch
  (`DoctrineCollector::debugToolbarDisplayPublic()`)
  were removed — both
  were dead code.

  ## Why

  Cross-checking `src/`, `tests/`, `docs/` and the CI
  configuration
  surfaced:

  - A documented helper that did not exist
  (`getFromCacheOrQuery()`).
  - A documented filter that was a no-op
  (`DoctrineSlcReset`).
  - Operators that failed silently instead of validating
    (`[><]` with the wrong arity, DataTables `regex:
  true`).
  - A regex with a stray `•` (U+2022) accepting
  unintended prefixes.
  - `rector.php` targeting PHP 7.4 while `composer.json`
   requires PHP ≥ 8.2.
  - PHP 8.5 in the CI matrix while it is still in alpha.
  - `Config/`, `Commands/` excluded from coverage.
  - Two Spanish inline comments in production code.
  - README documenting an operator (`[*%]`) that was
  never implemented and
    links to two `.md` files that do not exist.

  ## Commits (in order)

  | # | Commit | Scope |
  |---|--------|-------|
  | 1 | `chore(tooling): bump Rector PHP target to 8.2
  and tighten CI matrix` | `rector.php`,
  `.php-cs-fixer.dist.php`, `phpunit.xml.dist`,
  `phpunit.yml` |
  | 2 | `feat(helpers): add getFromCacheOrQuery
  cache-aside helper` | new helper + tests + autoload
  entry |
  | 3 | `fix(slc-filter): make DoctrineSlcReset reset
  stats per request` | filter implementation + test |
  | 4 | `fix(datatables): strict operator parsing, [><]
  arity, reject regex flag` | `Builder` + edge-case
  tests |
  | 5 | `refactor(doctrine): add getEm() with null
  guards, drop dead code` | `Doctrine`,
  `DoctrinePublish`, `cli-config.php` |
  | 6 | `refactor(cache): consolidate Memcached/Redis
  wrappers via shared trait` | new
  `InitializesNativeClient` trait |
  | 7 | `refactor(toolbar): memoize SLC lookup, FIFO
  buffer, drop test escape hatch` | collector +
  middleware |
  | 8 | `test: add Services coverage, idempotent seeder,
   support cs-fixes` | `ServicesTest`, idempotent
  `TestSeeder` |
  | 9 | `docs: comprehensive update aligned with current
   code, add CHANGELOG` | every `.md` + new
  `CHANGELOG.md` |

  ## Highlights

  ### New API

  - `Daycry\Doctrine\Helpers\getFromCacheOrQuery()` —
  cache-aside helper
    backed by Doctrine's configured `resultsCache` PSR-6
   pool, autoloaded
    globally.
  - `Doctrine::getEm()` — typed accessor that throws if
  the
    `EntityManager` is not initialised.
  - `Builder::withMaxFilterValues(int)` — caps `[IN]` /
  `[OR]` value lists
    (default 500; DoS guard).
  - `DoctrineCollector::setMaxQueries(int)` — FIFO
  discard for
    long-running CLI workers.
  - `Daycry\Doctrine\Libraries\InitializesNativeClient`
  trait — shared by
    `Memcached` and `Redis` wrappers, returning precise
  types instead of
    `mixed`.

  ### Behaviour changes

  - `Builder` operator `[><]` now throws
  `InvalidArgumentException` if
    the value count is not exactly 2 (was a silent
  drop).
  - `Builder` rejects DataTables `search.regex: true`
  and
    `columns[*].search.regex: true` with
  `InvalidArgumentException` (was
    silently ignored).
  - `DoctrineSlcReset::before()` now actually calls
    `Services::doctrine()->resetSecondLevelCacheStatisti
  cs()`.
  - `DoctrinePublish` returns exit code `1` on every
  error path.
  - `Builder::parseFilterOperator()` regex restricted to
   documented
    tokens.

  ### Tooling / CI

  - `rector.php` targets PHP 8.2 (matches
  `composer.json`); applies
    `match` expressions, constructor promotion and 8.x
  refactors.
  - `.php-cs-fixer.dist.php` now formats `tests/` too.
  - `phpunit.xml.dist` only excludes
  `src/cli-config.php` from coverage
    (`src/Config/`, `src/Commands/`, `src/Cache/` are
  now covered).
  - PHP 8.5 dropped from the `phpunit.yml` matrix until
  GA.

  ### Documentation

  - Canonical operator reference moved to
  `docs/search_modes.md`. Both
    `README.md` and `docs/datatables.md` link to it
  instead of duplicating
    the table.
  - New sections: `Requirements`, `Features`,
  `Multi-Database Groups`,
    `Memory Management`, `Resetting Stats per Request`,
    `Manual Result Caching`.
  - Full `Options Reference` table in
  `docs/configuration.md` covering
    `proxyFactory`, `customTypeMappings`,
  `secondLevelCacheTtl`.
  - New `CHANGELOG.md` (Keep a Changelog 1.1.0).
  - Broken links to `DATATABLES_FIX.md` /
  `TEST_COVERAGE.md` removed.


  - `rector.php` targets PHP 8.2 (matches `composer.json`); applies
    `match` expressions, constructor promotion and 8.x refactors.
  - `.php-cs-fixer.dist.php` now formats `tests/` too.
  - `phpunit.xml.dist` only excludes `src/cli-config.php` from coverage
    (`src/Config/`, `src/Commands/`, `src/Cache/` are now covered).
  - PHP 8.5 dropped from the `phpunit.yml` matrix until GA.

  ### Documentation

  ### Documentation

  - Canonical operator reference moved to `docs/search_modes.md`. Both
    `README.md` and `docs/datatables.md` link to it instead of duplicating
    the table.
  - New sections: `Requirements`, `Features`, `Multi-Database Groups`,
    `Memory Management`, `Resetting Stats per Request`,
    `Manual Result Caching`.
  - Full `Options Reference` table in `docs/configuration.md` covering
    `proxyFactory`, `customTypeMappings`, `secondLevelCacheTtl`.
  - New `CHANGELOG.md` (Keep a Changelog 1.1.0).
  - Broken links to `DATATABLES_FIX.md` / `TEST_COVERAGE.md` removed.

  ## Test plan

  - [x] `composer cs-fix` clean
  - [x] `composer phpstan` (level 6) — no errors
  - [x] `composer rector` dry-run — no changes
  - [x] `composer test --filter "DoctrineCollector|Services|GetFromCacheOrQuery|DoctrineSlcReset|DataTablesBuilder|BuilderCoverage"` — 78/78
  green locally