### PR TITLE
Audit-driven improvements: capabilities, performance, fixes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,61 @@
+name: Docs
+
+on:
+  push:
+    # Publish only from the development branch (the github-pages environment's
+    # allowed branch).
+    branches: [development]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'docs/requirements.txt'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+# Allow this workflow to publish to GitHub Pages.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One concurrent deploy; don't cancel an in-progress production deploy.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build (MkDocs Material)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: docs/requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r docs/requirements.txt
+
+      - name: Build site (strict — fails on any broken link/anchor)
+        run: mkdocs build --strict --site-dir site
+
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    # Publish only from the development branch; never from forks/PRs.
+    if: github.ref == 'refs/heads/development'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,0 +1,350 @@
+# Auditoría exhaustiva — `daycry/doctrine`
+
+**Fecha:** 2026-06-06 · **Rama:** `refactor/audit-and-docs` · **Alcance:** capacidades, rendimiento, optimización, correctitud, seguridad, calidad, dependencias, tests y docs.
+
+**Método:** 13 auditores en paralelo (uno por dimensión, leyendo el código real) → verificación adversarial *finding-por-finding* contra el código citado → crítico de completitud → síntesis. 112 agentes, 97 hallazgos, **95 verificados**, 2 rechazados. Cada hallazgo cita `archivo:línea` real.
+
+---
+
+## Resumen ejecutivo
+
+El núcleo de la librería es **sólido, está bien tipado y bien probado (~90,5 %)**. La verificación adversarial degradó muchos "falta la capacidad X" a "falta una *superficie de configuración* de primera clase" — porque el *escape hatch* de Doctrine ya existe vía `getEm()->getConfiguration()`. Es decir: la mayor parte del trabajo de mejora es **aditivo y retrocompatible**, no corrección de fallos.
+
+Dicho esto, hay un punto ciego sistemático: el **comportamiento operacional en producción y procesos largos** (workers CLI/cola, multi-grupo de BD), que es justo el caso de uso que la librería promociona. Ahí están los defectos reales de mayor valor.
+
+**Lo más accionable, en una frase:**
+
+1. **`reOpen()` no reconecta** — reutiliza la misma conexión DBAL muerta, contradiciendo lo que vende su documentación para workers. *(el defecto headline)*
+2. El **middleware de captura de queries se monta siempre** (también en producción sin toolbar) y, a la vez, **no hay ningún logging de queries en producción** (las dos caras del mismo diseño).
+3. Tres bugs de bajo esfuerzo y alto valor: **`[OR]` ignora `caseInsensitive`**, **DataTables no acota `length`** (`length=-1` → hidrata la tabla entera) y los **docs citan comandos `orm:convert-mapping`/`orm:generate-entities` eliminados en ORM 3**.
+4. **`doctrine/dbal` sin fijar** en `composer.json` (el código usa APIs solo-DBAL-4) y **`jms/serializer-bundle` es dependencia dura sin un solo uso** en `src/`.
+5. El mayor multiplicador de **capacidades** (tu objetivo #1): exponer como config los puntos de extensión que Doctrine ya ofrece — **Types personalizados, SQL Filters, event listeners, middlewares DBAL, repository factory, comandos `spark`, `cli-config` multi-grupo, logging de queries lentas, migraciones**.
+
+---
+
+## Veredicto por área
+
+| Área | Estado | Acción de mayor valor |
+|---|---|---|
+| Núcleo (EM, conexión, multi-DB) | 🟢 Sólido | Arreglar `reOpen()` (reconexión real) |
+| DataTables Builder | 🟡 Correcto pero con bordes | Acotar `length`; `[OR]` case-insensitive; cachear `count` |
+| Caché (query/result/metadata/SLC) | 🟡 Funciona, sub-óptimo | Claves por grupo de BD; TTL persistente de metadata; región SLC con lock-dir |
+| Capacidades ORM | 🟠 Mínimas superficies de config | Exponer Types/Filters/listeners/middlewares/repos |
+| Tooling / CLI | 🟠 Solo `doctrine:publish` | Wrappers `spark` + `cli-config` multi-grupo |
+| Seguridad | 🟢 Buena base (params, escaping, caps) | Cap de `length` y de nº de columnas |
+| Observabilidad producción | 🔴 Inexistente | Logging PSR-3 de queries/slow-queries |
+| Análisis estático | 🟡 Nivel 6 + muchas supresiones | Subir a nivel 8 arreglando 2-3 tipos raíz |
+| Dependencias | 🟠 1 sin fijar, 1 muerta | Fijar `dbal ^4`; quitar `jms/serializer-bundle` |
+| Documentación | 🟡 Drift puntual | Quitar comandos ORM 2; corregir `[OR]` |
+
+---
+
+## 1 · Correcciones prioritarias (P0) — fallos reales, esfuerzo bajo
+
+> Todas retrocompatibles salvo donde se indica. Verificadas contra el código.
+
+### 1.1 · `reOpen()` no reconecta una conexión muerta — **HIGH (correctitud)**
+[src/Doctrine.php:220-225](src/Doctrine.php#L220-L225)
+
+```php
+public function reOpen(): void
+{
+    $em       = $this->getEm();
+    $this->em = new EntityManager($em->getConnection(), $em->getConfiguration());
+    $this->registerTypeMappings(config('Doctrine'));
+}
+```
+
+Crea un nuevo `EntityManager` sobre **la misma `Connection` DBAL**. Nunca llama `close()`/`isConnected()`, así que tras un `wait_timeout` del servidor (*"MySQL server has gone away"*) devuelve un EM que **vuelve a fallar en la siguiente query**. Y [docs/usage.md:54](docs/usage.md#L54) lo vende exactamente como el remedio para "workers que acaban con un EntityManager cerrado".
+
+**Fix:** cerrar la conexión para forzar la reconexión perezosa de DBAL antes de reconstruir el EM:
+```php
+public function reOpen(): void
+{
+    $connection = $this->getEm()->getConnection();
+    if ($connection->isConnected()) {
+        $connection->close(); // DBAL reconecta perezosamente en el próximo uso
+    }
+    $this->em = new EntityManager($connection, $this->getEm()->getConfiguration());
+    $this->registerTypeMappings(config('Doctrine'));
+}
+```
+Y corregir el docblock invertido de [docs/usage.md:62-64](docs/usage.md#L62-L64) (`getEm()` nunca devuelve null).
+
+### 1.2 · DataTables no acota `length` → hidratación de tabla completa — **MEDIUM (seguridad/DoS)**
+[src/DataTables/Builder.php:527-537](src/DataTables/Builder.php#L527-L537)
+
+`applyPagination()` solo fija `setMaxResults` cuando `length > 0`. DataTables envía `length=-1` para *"All"*: el endpoint hidrata **toda la tabla filtrada como entidades gestionadas**. Es el vector de agotamiento de memoria más directo de la feature estrella (hay caps para `maxFilterValues` y para el término de búsqueda, pero no para el tamaño de página).
+
+**Fix:** `withMaxPageLength(int)` con tope por defecto razonable; cuando `length <= 0` o supera el tope, aplicar el tope en vez de "sin límite".
+
+### 1.3 · `[OR]` ignora `withCaseInsensitive(true)` — **MEDIUM (correctitud, confirmado)**
+[src/DataTables/Builder.php:264-283](src/DataTables/Builder.php#L264-L283)
+
+Las ramas `=`, `!=`, `<`, `>`, `%` envuelven en `lower(...)`; **`IN`, `OR` y `[><]` usan el campo crudo**. [docs/search_modes.md:76-77](docs/search_modes.md#L76-L77) documenta `[OR]` como case-insensitive. Envolver campo y placeholder en `lower()` cuando el flag está activo (igual que la búsqueda global).
+
+### 1.4 · `doctrine/dbal` sin fijar en `composer.json` — **MEDIUM (dependencia)**
+[composer.json:18-25](composer.json#L18-L25)
+
+El código usa APIs **solo-DBAL-4** (`ServerVersionProvider`, firmas `Driver/Statement/Connection` de DBAL 4) pero `dbal` solo entra transitivamente; `orm ^3` permite resolver DBAL 3.8.x → fallo fatal latente. Añadir `"doctrine/dbal": "^4"`. (Trivial, y ya coincide con lo que [README.md:31](README.md#L31) afirma.)
+
+### 1.5 · Docs citan comandos eliminados en ORM 3 — **HIGH (docs, confirmado)**
+[README.md:126-127](README.md#L126-L127) · [docs/cli_commands.md:35-39](docs/cli_commands.md#L35-L39)
+
+`orm:convert-mapping` y `orm:generate-entities` **no existen en Doctrine ORM 3**: los ejemplos fallan. Sustituir por los que sí envía ORM 3 (`orm:schema-tool:*`, `orm:validate-schema`, `orm:info`, `orm:mapping:describe`, `orm:run-dql`, `dbal:run-sql`).
+
+### 1.6 · `getFromCacheOrQuery`: claves sin validar + footgun de entidades — **LOW→MEDIUM**
+[src/Helpers/getFromCacheOrQuery.php:26-47](src/Helpers/getFromCacheOrQuery.php#L26-L47)
+
+(a) `$cacheKey` se pasa a PSR-6 sin validar → `InvalidArgumentException` en runtime con caracteres reservados `{}()/\@:`. (b) Cachea el retorno *tal cual*: si el llamante devuelve entidades gestionadas/proxies, se serializan **detached** y revientan al rehidratar. Validar/normalizar la clave y documentar "solo escalares/arrays, nunca entidades".
+
+---
+
+## 2 · Expansión de capacidades (objetivo #1) — aditivo, retrocompatible
+
+Patrón unificado: **una entrada en `Config\Doctrine` + un bucle en el constructor**, igual que ya se hace con las funciones DQL y `customTypeMappings`. Todo esto hoy solo es accesible "por debajo" vía `getEm()->getConfiguration()`; la mejora es hacerlo **first-class y documentado**.
+
+| Capacidad | Valor | Boceto | Hallazgo |
+|---|---|---|---|
+| **Custom DBAL Types** (`Type::addType`) | Claves UUID/ULID, value objects | `public array $customTypes = []` + `if (!Type::hasType($n)) Type::addType($n,$c)` (guard obligatorio: estado global) | `cap-orm-features-3` |
+| **SQL Filters** | Soft-delete, multi-tenant | `$sqlFilters`/`$enabledFilters` → `$config->addFilter()` + `getFilters()->enable()` (re-aplicar en `reOpen()`) | `cap-orm-features-4` |
+| **Event listeners/subscribers** | `onFlush`, auditoría, hooks | `EventManager` construido desde config y pasado como 3er arg del EM (y en `reOpen()`) | `cap-orm-features-2` |
+| **Middlewares DBAL del usuario** | Retry, logging, métricas | `$dbalMiddlewares` → `setMiddlewares([...$user, $toolbar])` (no sobrescribir) | `cap-orm-features-7` |
+| **Repository factory / default repo** | DX de repos | `setDefaultRepositoryClassName` / `setRepositoryFactory` desde config | `cap-orm-features-5` |
+| **Helpers de batch** | Jobs largos sin fugas | `toIterable()` + `clear()` periódico envuelto | `cap-orm-features-6` |
+| **Binding `EntityManagerInterface`** | Inyección por constructor | Registrar el servicio para DI directa del EM | `cap-orm-features-1` |
+| **Comandos `spark doctrine:*`** | `schema:update`, `cache:clear`, `info`, `validate`, `proxies` | `BaseCommand` que resuelve `service('doctrine')->getEm()` → `SingleManagerProvider` → comando ORM 3 vía `ArrayInput` | `cap-tooling-1` |
+| **`cli-config` multi-grupo** | DDL contra `reporting`/`legacy` | `MultipleManagerProvider` + flag `--em` (hoy `SingleManagerProvider` solo default → **riesgo de DDL contra la BD equivocada**) | crítico |
+| **Logging de queries en producción** | Observabilidad/slow-query | `Doctrine\DBAL\Logging\Middleware` (PSR-3) + `slowQueryThreshold` en config | crítico |
+| **`doctrine/migrations`** | Esquema versionado | En `suggest` + registro condicional (`class_exists`) en el hook `$commands` ya vacío de `cli-config` | `cap-tooling-3` |
+
+**Observabilidad multi-grupo (crítico):** el colector es **un singleton global** ([src/Config/Services.php:67-77](src/Config/Services.php#L67-L77)) compartido por todos los EM; las queries de `default`+`reporting`+`legacy` se mezclan en un panel sin atribución de conexión ([DoctrineQueryMiddleware.php:68-75](src/Debug/Toolbar/Collectors/DoctrineQueryMiddleware.php#L68-L75) no guarda identidad de grupo). Añadir la clave de grupo a cada query capturada.
+
+---
+
+## 3 · Rendimiento y optimización (objetivos #2 y #3)
+
+### Producción (hot path)
+- **Gatear el middleware/colector por `CI_DEBUG`** — [src/Doctrine.php:185-200](src/Doctrine.php#L185-L200) los monta siempre. En producción se pagan 3 asignaciones de clase anónima por *statement* + 2 `microtime` + push de array por query, para un panel que nunca se renderiza. *(Nuance del verificador: el buffer está acotado a 1000 con FIFO; no es una fuga, es overhead muerto.)* `perf-runtime-1/2`
+- **Caché de metadata/query persistente** — [src/Doctrine.php:83,91,99](src/Doctrine.php#L83) usan el TTL volátil del framework (default 60 s) para metadata/DQL, que son inmutables entre despliegues. Pasar `defaultLifetime = 0` para esos pools (invalidación por clear explícito). `caching-arch-5`
+- **Handler de caché desconocido → `ArrayAdapter`** — [src/Doctrine.php:102-103](src/Doctrine.php#L102-L103): cualquier handler distinto de file/redis/memcached (incluido el default `dummy` de CI4) deja metadata/query **sin persistencia entre requests**. Avisar o mapear explícitamente. `perf-runtime-3`
+
+### DataTables
+- **Cachear/inyectar `count`** — `recordsTotal`/`recordsFiltered` se recalculan en **cada draw** ([Builder.php:363-371,400-409](src/DataTables/Builder.php#L363-L371)). `withRecordsTotal(int|Closure)` y/o cache-aside opcional. `perf-datatables-4`
+- **`fetchJoinCollection` opcional** — hard-coded `true` ([Builder.php:130](src/DataTables/Builder.php#L130)) fuerza fetch en 2 queries aunque la query no tenga colección. `withFetchJoinCollection(bool)` (default true por BC). `perf-datatables-3`
+- **Hidratación read-only + `clear()`** en el hot path de DataTables (entidades gestionadas y change-tracked por página, sin tope de memoria). Exponer `HINT_READ_ONLY`. crítico
+
+### Helper cache-aside
+- `getFromCacheOrQuery` **construye el servicio Doctrine completo** solo para leer el pool ([helper:28-29](src/Helpers/getFromCacheOrQuery.php#L28)); además **sin protección anti-stampede**. Aligerar el acceso al pool y opcionalmente añadir lock. `caching-arch-7`
+
+---
+
+## 4 · Calidad, análisis estático y CI
+
+- **Subir PHPStan a nivel 8** arreglando **dos tipos raíz** que generan la mayoría de errores: el parámetro `object` de `convertDbConfig` ([Doctrine.php:248](src/Doctrine.php#L248), ~23 de 43 errores nivel 8) y la unión `ORMQueryBuilder|QueryBuilder|null` del Builder. `static-analysis-2/1`
+- **Reducir la lista de supresiones de Psalm** atacando su causa: el `?array $requestParams` nullable del Builder (familia `PossiblyNull*`) con un accesor privado tipado. `static-analysis-3`
+- **`rector.php`** omite `TYPE_DECLARATION`, `CODE_QUALITY` y `STRICT_BOOLEANS`. `static-analysis-7`
+- **Infection (mutation testing)** ausente pese al ~90 %: validaría la calidad de las aserciones. `testing-ci-3`
+- **Gates de CI** faltantes: `composer validate`, `composer-normalize --dry-run`, y *security audit* de dependencias. `testing-ci-4`
+- **Tests faltantes de alto valor:** mapeos de driver Postgres/SQLSRV/OCI8 de `convertDbConfig`, `reOpen`+`registerTypeMappings`, claves reservadas de `getFromCacheOrQuery`, rama null de `Memcached::getInstance()`. `testing-ci-2/6/7/8`
+
+---
+
+## 5 · Dependencias
+
+- **Quitar `jms/serializer-bundle`** ([composer.json:23](composer.json#L23)) — **0 referencias en `src/`** (confirmado), pero arrastra `symfony/framework-bundle` y su árbol. Riesgo extra (crítico): un **segundo árbol Symfony** con restricciones independientes de `symfony/cache ^7` → superficie de conflicto del resolutor. La anotación que mencionan los docs vive en `jms/serializer` (ligero), no en el bundle.
+- **Fijar `doctrine/dbal ^4`** (ver §1.4).
+- `ext-redis`/`ext-memcached` en `suggest`; revisar `minimum-stability: dev`. `deps-compat-3/4`
+
+---
+
+## 6 · Documentación
+
+Drift puntual a corregir: comandos ORM 2 (§1.5), `[OR]` case-insensitive (§1.3), "Requirements" dice DBAL ^4 sin requerirlo, docblock invertido de `reOpen()`, y documentar la **precondición no obvia**: el Paginator de DataTables **exige un SELECT de entidad** (un `SELECT u.id, u.name` escalar o con `GROUP BY` rompe de forma opaca). `docs-accuracy-*`, crítico
+
+---
+
+## Roadmap secuenciado
+
+**Sprint 1 — Quick wins (trivial/small, mayoría BC):**
+`reOpen()` reconexión · cap de `length` · `[OR]` case-insensitive · fijar `dbal ^4` · quitar `jms/serializer-bundle` · docs comandos ORM 3 · gatear middleware por `CI_DEBUG` · `cli-config` `__DIR__` · bounds-check en `applyOrdering` · TTL persistente de metadata.
+
+**Sprint 2 — Capacidades (aditivo):**
+`customTypes` · `sqlFilters` · `eventListeners` · `dbalMiddlewares` · logging de queries/slow-query en producción · comandos `spark doctrine:*`.
+
+**Sprint 3 — Profundidad:**
+`cli-config` multi-grupo (`--em`) · caché de `count` + `fetchJoinCollection` opcional + read-only en DataTables · claves de caché por grupo de BD · región SLC con lock-dir · PHPStan 8 + Infection + gates CI · `doctrine/migrations` (suggest) · tests faltantes.
+
+---
+
+## Apéndice A — 95 hallazgos verificados
+
+> `*(nuance)*` = el verificador confirmó el hallazgo pero corrigió/calibró su alcance o severidad.
+### Performance — hot path
+
+| Sev | Cat | Finding | Location | Effort |
+|---|---|---|---|---|
+| medium | performance | DBAL query-capturing middleware is wired unconditionally on every request, even in production with no toolbar *(nuance)* | `src/Doctrine.php:185-200` | small |
+| low | performance | Collector accumulates every query in memory even when the toolbar will never render *(nuance)* | `src/Debug/Toolbar/Collectors/DoctrineCollector.php:53-60` | small |
+| low | performance | Unrecognized cache handler silently falls back to ArrayAdapter, rebuilding metadata/query cache every request *(nuance)* | `src/Doctrine.php:102-103` | medium |
+| low | performance | Full EntityManager + Configuration + cache adapters + DQL functions rebuilt on every cold service resolve *(nuance)* | `src/Doctrine.php:60-203` | medium |
+| low | performance | Proxy autogeneration/native-lazy choice keyed to ENVIRONMENT can force per-request proxy regen in non-standard envs *(nuance)* | `src/Config/Doctrine.php:101, src/Doctrine.php:108-118` | small |
+| low | performance | PhpFilesAdapter for the result cache makes result caching effectively unusable for dynamic data *(nuance)* | `src/Doctrine.php:80-84, 313-319` | small |
+| low | performance | doctrineCollector and reset filter trigger full Doctrine service construction even when SLC stats disabled *(nuance)* | `src/Debug/Filters/DoctrineSlcReset.php:30-39` | trivial |
+| info | performance | is_dir() filesystem stat over every entity path on every construction *(nuance)* | `src/Doctrine.php:72-76` | trivial |
+
+### Performance — DataTables
+
+| Sev | Cat | Finding | Location | Effort |
+|---|---|---|---|---|
+| medium | performance | Count queries never cached; recordsTotal/recordsFiltered recomputed on every draw | `src/DataTables/Builder.php:363-371,400-409` | medium |
+| low | performance | getResponse() re-clones/re-parses the filtered query for the data Paginator + redundant filtered-count Paginator *(nuance)* | `src/DataTables/Builder.php:378-411` | small |
+| low | performance | fetchJoinCollection hard-coded true → two-query page fetch even when the query joins no collection *(nuance)* | `src/DataTables/Builder.php:130,388` | medium |
+| low | correctness | DBAL QueryBuilder accepted by the union/docs but the Paginator path can only execute ORM QueryBuilder *(nuance)* | `src/DataTables/Builder.php:52,468,130` | large |
+| info | performance | getData()+getRecordsFiltered() called separately re-run getFilteredQuery() twice *(nuance)* | `src/DataTables/Builder.php:123-139,351-358` | medium |
+| info | capability | No way to pass Query hints (HINT_ENABLE_DISTINCT / read-only / fetch mode) to paginated queries *(nuance)* | `src/DataTables/Builder.php:130-138` | medium |
+| info | correctness | getRecordsFiltered() omits the validate() every other entry point calls *(nuance)* | `src/DataTables/Builder.php:351-358` | trivial |
+
+### Caching architecture
+
+| Sev | Cat | Finding | Location | Effort |
+|---|---|---|---|---|
+| medium | correctness | Result/query/SLC cache namespaces not keyed per DB group → cross-database key collisions return wrong data *(nuance)* | `src/Doctrine.php:81-99` | small |
+| medium | correctness | SLC READ_WRITE entities throw LogicException — file-lock region directory never configured *(nuance)* | `src/Doctrine.php:150` | small |
+| low | correctness | getFromCacheOrQuery passes $cacheKey to PSR-6 unvalidated — runtime exception on reserved chars *(nuance)* | `src/Helpers/getFromCacheOrQuery.php:35` | trivial |
+| low | correctness | getFromCacheOrQuery docblock claims 'ttl 0 = no expiration' but pool defaultLifetime overrides it *(nuance)* | `src/Helpers/getFromCacheOrQuery.php:21,42-44` | trivial |
+| low | performance | Metadata cache uses the volatile framework TTL (default 60s) instead of being persistent *(nuance)* | `src/Doctrine.php:83,91,99` | trivial |
+| low | quality | createSecondLevelCachePool duplicates the adapter-construction switch already in __construct *(nuance)* | `src/Doctrine.php:78-104 vs 313-345` | medium |
+| low | performance | Result-cache cache-aside helper has no stampede protection; concurrent misses all hit the DB *(nuance)* | `src/Helpers/getFromCacheOrQuery.php:35-45` | small |
+| info | quality | SLC region default lock lifetime hardcoded to 60 and not configurable *(nuance)* | `src/Doctrine.php:141-144` | trivial |
+
+### Capabilities — ORM
+
+| Sev | Cat | Finding | Location | Effort |
+|---|---|---|---|---|
+| medium | capability | Custom DBAL Type registration (Type::addType) missing — only type *mappings* supported *(nuance)* | `src/Doctrine.php:230-237` | small |
+| medium | capability | No SQL Filter registration — soft-delete and multi-tenant scoping cannot be wired first-class *(nuance)* | `src/Config/Doctrine.php (no filter property)` | small |
+| low | capability | No EntityManagerInterface binding for constructor DI *(nuance)* | `src/Config/Services.php:17-33` | trivial |
+| low | capability | Lifecycle event subscribers/listeners cannot be registered — EM built with an empty EventManager *(nuance)* | `src/Doctrine.php:200` | small |
+| low | capability | No custom repository / repository factory wiring *(nuance)* | `src/Doctrine.php:106-203` | medium |
+| low | capability | No batch-processing helpers (toIterable + periodic clear) for long jobs *(nuance)* | `src/Doctrine.php:217-225` | small |
+| low | capability | User-defined DBAL middlewares cannot be composed — toolbar middleware hardcoded as the only entry *(nuance)* | `src/Doctrine.php:187-198` | small |
+| low | capability | No naming/quoting strategy, default query hints, or custom hydrators configuration | `src/Doctrine.php:106-165` | small |
+
+### Capabilities — tooling/CLI
+
+| Sev | Cat | Finding | Location | Effort |
+|---|---|---|---|---|
+| medium | capability | All ORM tasks require manual `php cli-config.php`; no spark wrappers exist *(nuance)* | `src/cli-config.php:71-74` | medium |
+| medium | docs | Documented ORM CLI commands orm:convert-mapping / orm:generate-entities were REMOVED in ORM 3 | `docs/cli_commands.md:35-38, README.md:126-127` | trivial |
+| low | capability | No doctrine/migrations integration; schema management limited to non-versioned schema-tool *(nuance)* | `src/cli-config.php:66-69` | large |
+| low | dx | cli-config.php requires 'vendor/autoload.php' via CWD-relative path, breaking invocation from other dirs *(nuance)* | `src/cli-config.php:11` | trivial |
+| low | dx | No health-check / diagnostics command *(nuance)* | `src/Config/Services.php:40-46` | medium |
+| low | capability | No data-fixtures support tied to the Doctrine EntityManager *(nuance)* | `composer.json:18-36` | medium |
+| low | dx | DoctrinePublish hardcodes cli-config destination to project root; no path/dbGroup options *(nuance)* | `src/Commands/DoctrinePublish.php:64` | small |
+
+### Correctness — DataTables
+
+| Sev | Cat | Finding | Location | Effort |
+|---|---|---|---|---|
+| medium | correctness | [OR] operator ignores withCaseInsensitive(true), contradicting the docs | `src/DataTables/Builder.php:273-282` | small |
+| low | correctness | applyOrdering indexes columns by client-supplied order.column with no bounds check *(nuance)* | `src/DataTables/Builder.php:510-512` | trivial |
+| low | docs | Global search term silently truncated to 255 characters with no documentation *(nuance)* | `src/DataTables/Builder.php:170` | trivial |
+| low | correctness | Per-column filter ignores searchableColumns whitelist (only global search is constrained) | `src/DataTables/Builder.php:180-182,205-313` | small |
+| info | correctness | Per-column filter value has no length cap while global search truncates to 255 *(nuance)* | `src/DataTables/Builder.php:170,208` | small |
+| info | correctness | parseFilterOperator fallback re-attaches the raw bracket prefix when preg_replace returns null *(nuance)* | `src/DataTables/Builder.php:332,337,345` | trivial |
+
+### Correctness — core
+
+| Sev | Cat | Finding | Location | Effort |
+|---|---|---|---|---|
+| low | correctness | dbGroup defaulting hardcodes 'tests' and overrides the consumer's defaultGroup in testing *(nuance)* | `src/Doctrine.php:193-195` | trivial |
+| low | correctness | SQLite DSN detection is a case-sensitive substring match; whole-DSN lowercasing can corrupt file paths *(nuance)* | `src/Doctrine.php:253-254` | trivial |
+| low | correctness | Postgres uses different DBAL drivers (charset-dropping 'pgsql' vs 'pdo_pgsql') for DSN vs discrete config *(nuance)* | `src/Doctrine.php:252,275-289` | small |
+| low | correctness | Services singleton key lowercased but dbGroup passed to EM build is not — case-mismatch wrong-group instance *(nuance)* | `src/Config/Services.php:17-33` | trivial |
+| low | quality | Boot::bootDoctrine duplicates the framework boot sequence and runs full HTTP init for a CLI bootstrap *(nuance)* | `src/Boot.php:12-33` | small |
+| low | correctness | cli-config.php requires vendor/autoload.php via cwd-relative path before establishing FCPATH | `src/cli-config.php:11,20-25` | trivial |
+| info | correctness | convertDbConfig sends 'port' => null and a charset for drivers that may not want them *(nuance)* | `src/Doctrine.php:281-289` | trivial |
+| info | correctness | reOpen() correctly preserves middleware and type mappings — confirmed NOT a defect (idempotent) *(nuance)* | `src/Doctrine.php:220-237` | trivial |
+
+### Security
+
+| Sev | Cat | Finding | Location | Effort |
+|---|---|---|---|---|
+| low | security | Per-column filter/search loops have no upper bound on column count (request-amplification DoS) *(nuance)* | `src/DataTables/Builder.php:151,161,174,205` | small |
+| low | security | applyOrdering() indexes the columns array with an unvalidated, attacker-controlled order index *(nuance)* | `src/DataTables/Builder.php:510-512` | trivial |
+| low | security | Filter operators do not require the searchableColumns allow-list — relies solely on Doctrine to reject unmapped fields *(nuance)* | `src/DataTables/Builder.php:180-187` | small |
+| info | security | getFromCacheOrQuery passes caller key verbatim to PSR-6 — reserved-char DoS and no tenant namespacing *(nuance)* | `src/Helpers/getFromCacheOrQuery.php:26,35` | small |
+| info | security | convertDbConfig copies $db->options and SSL options verbatim into DBAL params (config-trust boundary) *(nuance)* | `src/Doctrine.php:291-303` | small |
+| info | security | Debug toolbar SQL/param rendering is correctly escaped (no XSS) — verified, no change needed *(nuance)* | `src/Debug/Toolbar/Collectors/DoctrineCollector.php:231-239,315` | trivial |
+| info | security | DQL identifier regex is sufficient against injection but accepts unbounded dotted association paths | `src/DataTables/Builder.php:588-595` | trivial |
+
+### Static analysis / quality
+
+| Sev | Cat | Finding | Location | Effort |
+|---|---|---|---|---|
+| medium | quality | Builder's ORMQueryBuilder\|QueryBuilder\|null union is the largest driver of Psalm's blanket suppressions; the DBAL member is non-functional *(nuance)* | `src/DataTables/Builder.php:52,146` | small |
+| medium | quality | convertDbConfig() types its parameter as bare `object`, producing 23 of the 43 level-8 errors in Doctrine.php | `src/Doctrine.php:248,250-299` | medium |
+| low | quality | Nullable $requestParams drives the PossiblyNull* suppression family; a private typed accessor eliminates it *(nuance)* | `src/DataTables/Builder.php:59,127` | small |
+| low | correctness | Native cache-client return types are nullable, forcing per-call ArgumentTypeCoercion suppressions *(nuance)* | `src/Doctrine.php:88-91,322-339` | small |
+| low | correctness | DoctrinePublish::$sourcePath declared string but assigned realpath() (string\|false) *(nuance)* | `src/Commands/DoctrinePublish.php:23,43` | small |
+| low | quality | Two @var suppressions in Services.php caused by getSharedInstance() returning a too-narrow inferred type *(nuance)* | `src/Config/Services.php:27,71` | small |
+| low | quality | rector.php omits TYPE_DECLARATION, CODE_QUALITY sets and STRICT_BOOLEANS *(nuance)* | `rector.php:31,68-86` | medium |
+| info | quality | DQL custom-function registration loses the FunctionNode subtype, forcing argument.type at higher levels *(nuance)* | `src/Doctrine.php:168-183` | trivial |
+
+### Dependencies
+
+| Sev | Cat | Finding | Location | Effort |
+|---|---|---|---|---|
+| medium | dependency | doctrine/dbal not required directly, yet code hard-depends on DBAL 4-only APIs *(nuance)* | `composer.json:18-25` | trivial |
+| medium | dependency | jms/serializer-bundle is a hard runtime require but never used in src/ and drags in the Symfony framework stack *(nuance)* | `composer.json:23` | small |
+| medium | dependency | Mandatory doctrine/dbal unpinned, exposing hard DBAL-internal coupling to silent major upgrades | `composer.json:18-25` | trivial |
+| low | dependency | minimum-stability: dev set with no dev-stability dependency declared *(nuance)* | `composer.json:72-73` | trivial |
+| low | dependency | ext-redis / ext-memcached runtime-required for those backends but absent from composer suggest *(nuance)* | `composer.json:18-36` | trivial |
+| low | dependency | ~100 custom DQL functions from two third-party packages registered unconditionally, hard-coupling both *(nuance)* | `src/Config/Doctrine.php:161-280` | medium |
+| info | dependency | PHP constraint uses open-ended >=8.2 while CI also tests an unreleased PHP 8.5 *(nuance)* | `composer.json:19` | trivial |
+
+### DX / API
+
+| Sev | Cat | Finding | Location | Effort |
+|---|---|---|---|---|
+| medium | dx | doctrine:publish ships a 293-line config that re-declares everything the new base class already provides *(nuance)* | `src/Commands/DoctrinePublish.php:80-82` | small |
+| low | dx | README/quick-start steer users to the public mutable `$em` property instead of getEm() *(nuance)* | `src/Doctrine.php:42, README.md:70,90,147` | trivial |
+| low | dx | Builder fluent API mixes withX()/setX() naming; create() builds an unusable object until validate() throws *(nuance)* | `src/DataTables/Builder.php:82-85,490-498` | small |
+| low | dx | Public exceptions span three unrelated hierarchies with no package marker interface *(nuance)* | `src/Doctrine.php:74,211` | medium |
+| low | dx | getFromCacheOrQuery needs `use function` while doctrine_instance is a true global — inconsistent access models *(nuance)* | `src/Helpers/getFromCacheOrQuery.php:5,26` | small |
+| info | correctness | getFromCacheOrQuery silently degrades to no-cache via an inconsistent-null EM path that bypasses the null guard *(nuance)* | `src/Helpers/getFromCacheOrQuery.php:28-33` | trivial |
+
+### Testing & CI
+
+| Sev | Cat | Finding | Location | Effort |
+|---|---|---|---|---|
+| medium | testing | convertDbConfig Postgres/SQLSRV/OCI8 driver mappings are entirely untested *(nuance)* | `src/Doctrine.php:248-308` | small |
+| low | testing | Filter-operator unit tests reimplement a divergent regex instead of calling the real parseFilterOperator() *(nuance)* | `tests/DataTablesBuilderTest.php:286` | small |
+| low | testing | No mutation testing (Infection) despite ~90% line coverage *(nuance)* | `composer.json:53-71` | medium |
+| low | dependency | CI lacks composer-validate, composer-normalize enforcement, and dependency security audit gates *(nuance)* | `.github/workflows/*.yml` | small |
+| low | testing | DataTables operator integration tests are MySQL-only; the SQLite leg never exercises the operator switch | `tests/DataTableTest.php` | medium |
+| low | testing | registerTypeMappings / customTypeMappings effect never asserted, and reOpen re-mapping untested *(nuance)* | `src/Doctrine.php:230-237` | small |
+| low | testing | getFromCacheOrQuery not tested with PSR-6 reserved-character keys *(nuance)* | `src/Helpers/getFromCacheOrQuery.php:35` | small |
+| low | testing | Memcached::getInstance() null-narrowing (Memcache fallback) branch has no test | `src/Libraries/Memcached.php:36-40` | trivial |
+
+### Docs
+
+| Sev | Cat | Finding | Location | Effort |
+|---|---|---|---|---|
+| high | docs | CLI docs reference orm:convert-mapping and orm:generate-entities — both removed in Doctrine ORM 3 | `README.md:126-127, docs/cli_commands.md:35-39` | small |
+| medium | docs | [OR] operator documented as case-insensitive but implementation ignores withCaseInsensitive() | `docs/search_modes.md:31,76-77` | trivial |
+| low | docs | README/installation 'Requirements' list DBAL ^4 but composer.json does not require doctrine/dbal *(nuance)* | `README.md:31` | trivial |
+| low | docs | No documentation for schema management / migrations workflow under ORM 3 | `docs/cli_commands.md:28-42` | small |
+| info | docs | search_modes matrix omits that [IN] values are exact, not wildcarded *(nuance)* | `docs/search_modes.md:30` | trivial |
+| info | docs | reOpen() doc says it 'throws if getEm() is null' — getEm() never returns null, wording inverts the contract *(nuance)* | `docs/usage.md:62-64` | trivial |
+
+### Rechazados por la verificación (2)
+
+- **`setUseOutputWalkers(true)` por defecto fuerza el walker caro en todo count/page** — El código existe (Builder.php:131,355,389…), pero el default `true` es la opción *segura* de Doctrine (sin él, queries con joins/HAVING devuelven counts erróneos). Es un trade-off defendible, no un defecto; ya es override-able.
+- **`[IN]` construye la lista de placeholders como string con `implode(',', …)` pasado a `Expr::in()`** — El código existe (Builder.php:257) pero `Expr::in()` acepta `string|array` por contrato; produce DQL válido y los params se enlazan. Frágil/sin documentar, no incorrecto.
+
+## Apéndice B — Metodología y trazabilidad
+
+- Resultado completo del workflow (JSON, 357 KB) con `description`, `evidence`, `recommendation`, `corrections` y `verdict`/`confidence` por hallazgo: disponible en el output de la tarea `ww3z98kia`.
+- 2 hallazgos **rechazados** por la verificación (al final del Apéndice A) y varios **no-defectos confirmados** (p. ej. el render del toolbar está correctamente escapado — sin XSS; `reOpen` sí preserva middleware y type-mappings; el default `OutputWalkers=true` es defendible).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Custom DBAL Types** — `Config\Doctrine::$customTypes` registers
+  `Doctrine\DBAL\Types\Type` subclasses via `Type::addType()` (idempotent),
+  applied on construction and `reOpen()`.
+- **SQL Filters** — `Config\Doctrine::$sqlFilters` / `$enabledFilters` register
+  and auto-enable Doctrine SQL filters (soft-delete, multi-tenant). Re-enabled
+  after `reOpen()`.
+- **Event listeners/subscribers** — `Config\Doctrine::$eventListeners` /
+  `$eventSubscribers` build an `EventManager` wired into the `EntityManager`
+  (and threaded through `reOpen()`).
+- **Composable DBAL middlewares** — `Config\Doctrine::$dbalMiddlewares` compose
+  user middlewares with the toolbar middleware (applied last/innermost).
+- **Default repository class** — `Config\Doctrine::$defaultRepositoryClass`.
+- **Production query logging** — `Config\Doctrine::$queryLogging`,
+  `$slowQueryThreshold`, `$queryLogLevel` log queries (optionally only slow
+  ones) to a PSR-3 logger via `Daycry\Doctrine\Logging\QueryLoggerMiddleware`,
+  in any environment (unlike the debug-only toolbar collector).
+- `Daycry\Doctrine\DataTables\Builder::withMaxPageLength(int)` caps the page
+  size, clamping unbounded `length=-1` ("All") / oversized requests.
+- **Spark commands** (group `Doctrine`): `doctrine:cache:clear`,
+  `doctrine:validate`, `doctrine:info`, `doctrine:schema:update` — each accepts
+  `--group` to target a database group.
+- `cli-config.php` exposes a lazy per-group `EntityManagerProvider`, so
+  `php cli-config.php orm:* --em=<group>` can target any database group.
 - `Daycry\Doctrine\Helpers\getFromCacheOrQuery()` cache-aside helper, autoloaded
   as a global function via `composer.json` `autoload.files`. Backed by the
   configured Doctrine `resultsCache` PSR-6 pool. Accepts an optional `$dbGroup`
@@ -31,6 +54,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reference in `docs/search_modes.md`.
 
 ### Changed
+- `Daycry\Doctrine\Doctrine::reOpen()` now closes the existing DBAL connection
+  so it is re-established on the next query, actually recovering from a stale /
+  dropped connection ("server has gone away") in long-running workers.
+- The Debug Toolbar query middleware/collector is only wired when query
+  instrumentation is enabled (`CI_DEBUG`), removing per-statement overhead in
+  production. Overridable via the protected `shouldInstrumentQueries()` seam.
+- `composer.json` — pin `doctrine/dbal ^4` explicitly (the code uses DBAL-4-only
+  APIs), remove the unused `jms/serializer-bundle`, and add `suggest` entries for
+  `ext-redis`, `ext-memcached` and `doctrine/migrations`.
+- `cli-config.php` requires `vendor/autoload.php` via `__DIR__` so it is
+  invokable from any working directory.
 - `Daycry\Doctrine\DataTables\Builder::parseFilterOperator()` regex now matches
   only documented operators (`!=, ><, >, <, =, %%, %, IN, OR, LIKE`); accidental
   `•` (U+2022) matches are no longer accepted. Unknown bracket prefixes
@@ -76,6 +110,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Broken doc links to `docs/DATATABLES_FIX.md` and `docs/TEST_COVERAGE.md`.
 
 ### Fixed
+- `Daycry\Doctrine\DataTables\Builder` — the `[OR]` operator now honors
+  `withCaseInsensitive(true)`, wrapping the column and placeholders in `lower()`
+  like the other operator branches and the global search.
+- `Daycry\Doctrine\DataTables\Builder::applyOrdering()` now bounds-checks the
+  client-supplied `order[].column` index instead of emitting an "Undefined array
+  key" warning on out-of-range values.
+- `README.md` / `docs/cli_commands.md` — replaced the `orm:convert-mapping` and
+  `orm:generate-entities` examples (removed in Doctrine ORM 3) with the schema
+  tooling that ORM 3 actually ships.
 - The documented helper `getFromCacheOrQuery()` now actually exists.
 - The documented `DoctrineSlcReset` filter now performs its job.
 - Doc-code mismatch around the `[*%]` operator in `README.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--group` to target a database group.
 - `cli-config.php` exposes a lazy per-group `EntityManagerProvider`, so
   `php cli-config.php orm:* --em=<group>` can target any database group.
+- `Daycry\Doctrine\DataTables\Builder::withFetchJoinCollection(bool)` — opt out
+  of `fetchJoinCollection` to collapse the page fetch into a single query for
+  scalar/single-entity SELECTs.
+- `Daycry\Doctrine\DataTables\Builder::withRecordsTotal(int|Closure)` — inject or
+  cache the unfiltered total so the COUNT query is skipped across draws.
 - `Daycry\Doctrine\Helpers\getFromCacheOrQuery()` cache-aside helper, autoloaded
   as a global function via `composer.json` `autoload.files`. Backed by the
   configured Doctrine `resultsCache` PSR-6 pool. Accepts an optional `$dbGroup`
@@ -54,6 +59,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reference in `docs/search_modes.md`.
 
 ### Changed
+- Doctrine query/result/metadata/SLC cache namespaces are now suffixed with the
+  (non-default) database group, preventing cross-group key collisions when
+  multiple groups share one cache backend. The default group is unchanged.
 - `Daycry\Doctrine\Doctrine::reOpen()` now closes the existing DBAL connection
   so it is re-established on the next query, actually recovering from a stale /
   dropped connection ("server has gone away") in long-running workers.
@@ -110,6 +118,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Broken doc links to `docs/DATATABLES_FIX.md` and `docs/TEST_COVERAGE.md`.
 
 ### Fixed
+- `Daycry\Doctrine\Doctrine::convertDbConfig()` now lower-cases only the DSN
+  scheme, preserving a case-sensitive SQLite file path (whole-DSN lowercasing
+  opened/created the wrong DB file on case-sensitive filesystems).
+- `getFromCacheOrQuery()` normalises PSR-6 reserved characters (`{}()/\@:`) in
+  the cache key instead of throwing at runtime.
 - `Daycry\Doctrine\DataTables\Builder` — the `[OR]` operator now honors
   `withCaseInsensitive(true)`, wrapping the column and placeholders in `lower()`
   like the other operator branches and the global search.

--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ $rows = getFromCacheOrQuery(
 ```
 
 When the result cache is disabled (`Config\Doctrine::$resultsCache = false`)
-the closure runs every time. PSR-6 reserves the characters
-`{}()/\@:` in cache keys — avoid them.
+the closure runs every time. PSR-6 reserved characters (`{}()/\@:`) in the key
+are normalised automatically, so any key string is accepted.
 
 See [docs/usage.md](docs/usage.md) for advanced API: `getEm()`, `reOpen()`,
 multi-database groups, `Services::resetDoctrine()`, and more.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Doctrine ORM 3 integration for CodeIgniter 4.
 - **Doctrine Second-Level Cache** wired to the framework cache backend (file, Redis, Memcached, array).
 - `getFromCacheOrQuery()` cache-aside helper backed by the configured PSR-6 result cache.
 - **Multi-database group support** — get a separate Doctrine instance per `Config\Database` group.
+- **Extensible** via config: custom DBAL **Types**, **SQL Filters** (soft-delete / multi-tenant), **event listeners/subscribers**, composable **DBAL middlewares** and a **default repository class**.
+- **Production query logging** (PSR-3) with an optional slow-query threshold — independent of the debug toolbar.
+- **Spark commands** (`doctrine:cache:clear`, `doctrine:validate`, `doctrine:info`, `doctrine:schema:update`) and a multi-group ORM CLI (`--em=<group>`).
 
 ## Requirements
 
@@ -149,6 +152,7 @@ $datatables = (new \Daycry\Doctrine\DataTables\Builder())
     ->withSearchableColumns(['p.name'])
     ->withCaseInsensitive(true)
     ->withMaxFilterValues(500) // cap [IN] / [OR] value lists; default 500
+    ->withMaxPageLength(200)   // cap page size; clamps length=-1 ("All") — default 0 (no cap)
     ->withQueryBuilder(
         $this->doctrine->em->createQueryBuilder()
             ->select('p.id, p.name')
@@ -232,6 +236,31 @@ The filter is a no-op unless `secondLevelCacheStatistics` is enabled.
 See [docs/second_level_cache.md](docs/second_level_cache.md) and
 [docs/second_level_cache_stats.md](docs/second_level_cache_stats.md) for full
 details.
+
+## Extending the EntityManager
+
+`Config\Doctrine` exposes additive, backward-compatible hooks (all default to
+off) for the common Doctrine extension points:
+
+```php
+// app/Config/Doctrine.php
+public array  $customTypes            = ['uuid' => \Ramsey\Uuid\Doctrine\UuidType::class];
+public array  $sqlFilters             = ['soft_delete' => \App\Doctrine\SoftDeleteFilter::class];
+public array  $enabledFilters         = ['soft_delete'];
+public array  $eventListeners         = ['onFlush' => [\App\Doctrine\AuditListener::class]];
+public array  $eventSubscribers       = [\App\Doctrine\TimestampSubscriber::class];
+public array  $dbalMiddlewares        = [\App\Doctrine\RetryMiddleware::class];
+public ?string $defaultRepositoryClass = \App\Repositories\BaseRepository::class;
+
+// Production query logging (PSR-3) — independent of the debug toolbar
+public bool   $queryLogging        = true;
+public float  $slowQueryThreshold  = 0.5;  // log queries slower than 500 ms
+public string $queryLogLevel       = 'warning';
+```
+
+All are re-applied across `Doctrine::reOpen()`. See
+[docs/configuration.md](docs/configuration.md#extension-points) for the full
+reference.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -123,14 +123,20 @@ multi-database groups, `Services::resetDoctrine()`, and more.
 Use the generated `cli-config.php` from the project root:
 
 ```bash
-php cli-config.php orm:convert-mapping --namespace="App\Models\Entity\\" --force --from-database annotation .
-php cli-config.php orm:generate-entities .
+php cli-config.php orm:validate-schema          # check mappings vs. database
+php cli-config.php orm:schema-tool:update --dump-sql   # preview schema changes
+php cli-config.php orm:schema-tool:update --force      # apply them
 php cli-config.php orm:generate-proxies app/Models/Proxies
+php cli-config.php orm:info                      # list mapped entities
+php cli-config.php orm:run-dql "SELECT u FROM App\Models\Entity\User u"
 ```
 
-If you encounter the JMS Serializer error *"The annotation
-@JMS\Serializer\Annotation\ExclusionPolicy was never imported"*, run
-`composer dump-autoload` to refresh annotation discovery.
+> Doctrine ORM 3 removed `orm:convert-mapping` and `orm:generate-entities`.
+> Reverse-engineering an existing schema into entities is no longer part of the
+> ORM toolchain; map your entities with PHP attributes (or XML) directly.
+
+The same commands are also available through Spark — see
+[docs/cli_commands.md](docs/cli_commands.md).
 
 ## DataTables
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ See [`composer.json`](composer.json) for the complete dependency graph.
 
 ## Documentation Index
 
+📖 **Full documentation site:** <https://daycry.github.io/doctrine/>
+
 - [Installation](docs/installation.md)
 - [Configuration](docs/configuration.md)
 - [Usage](docs/usage.md) — service, helper, multi-DB, `getFromCacheOrQuery`, advanced API

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
     "suggest": {
         "doctrine/migrations": "Versioned schema migrations integration for the Doctrine ORM CLI (php cli-config.php / spark doctrine:*)",
         "ext-memcached": "Required for the Memcached cache backend",
-        "ext-redis": "Required for the Redis cache backend"
+        "ext-redis": "Required for the Redis cache backend",
+        "jms/serializer-bundle": "Only if your entities use JMS Serializer annotations (e.g. when reverse-engineering mappings)"
     },
     "autoload-dev":
     {

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
     "license": "MIT",
     "require": {
         "php": ">=8.2",
-        "doctrine/orm": "^3",
-        "symfony/cache": "^7",
         "beberlei/doctrineextensions": "^1.0",
-        "jms/serializer-bundle": "^5",
-        "scienta/doctrine-json-functions": "^6.5"
+        "doctrine/dbal": "^4",
+        "doctrine/orm": "^3",
+        "scienta/doctrine-json-functions": "^6.5",
+        "symfony/cache": "^7"
     },
     "require-dev":
     {
@@ -41,6 +41,11 @@
         "files": [
             "src/Helpers/getFromCacheOrQuery.php"
         ]
+    },
+    "suggest": {
+        "doctrine/migrations": "Versioned schema migrations integration for the Doctrine ORM CLI (php cli-config.php / spark doctrine:*)",
+        "ext-memcached": "Required for the Memcached cache backend",
+        "ext-redis": "Required for the Redis cache backend"
     },
     "autoload-dev":
     {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,8 @@
 # Daycry Doctrine for CodeIgniter 4
 
+📖 **Online documentation:** <https://daycry.github.io/doctrine/> (built from this
+folder with MkDocs Material).
+
 Modern integration of Doctrine ORM/DBAL into CodeIgniter 4. Highlights:
 
 - ORM bootstrap via `\Daycry\Doctrine\Doctrine` and `Services::doctrine()`

--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -25,6 +25,22 @@ If you see *"APP_NAMESPACE not found in autoload psr4 configuration"*, ensure
 `composer.json`'s `autoload.psr-4` declares your `App\` namespace correctly,
 then run `composer dump-autoload`.
 
+### `doctrine:*` ORM wrappers
+
+These run the Doctrine ORM 3 console commands through Spark, using the
+CodeIgniter-resolved `EntityManager`. Each accepts `--group <db_group>` to target
+a specific database group (default group when omitted).
+
+```bash
+php spark doctrine:cache:clear [--group <db_group>]      # clear query/result/metadata caches
+php spark doctrine:validate    [--group <db_group>]      # orm:validate-schema
+php spark doctrine:info        [--group <db_group>]      # orm:info (list mapped entities)
+php spark doctrine:schema:update [--dump-sql] [--force] [--group <db_group>]
+```
+
+`doctrine:schema:update` defaults to a non-destructive `--dump-sql` dry run;
+pass `--force` to apply the changes.
+
 ## Doctrine ORM CLI
 
 These commands operate on the `cli-config.php` file generated above. Run them

--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -31,30 +31,33 @@ These commands operate on the `cli-config.php` file generated above. Run them
 from the project root (where `cli-config.php` lives):
 
 ```bash
-# Map an existing database to entity classes
-php cli-config.php orm:convert-mapping --namespace="App\Models\Entity\\" --force --from-database annotation .
+# Validate that the mapping matches the database schema
+php cli-config.php orm:validate-schema
 
-# Generate getters and setters
-php cli-config.php orm:generate-entities .
+# Preview the DDL needed to sync the schema (non-destructive)
+php cli-config.php orm:schema-tool:update --dump-sql
+
+# Apply the schema changes
+php cli-config.php orm:schema-tool:update --force
+
+# Create / drop the full schema
+php cli-config.php orm:schema-tool:create
+php cli-config.php orm:schema-tool:drop --force
 
 # Generate proxy classes
 php cli-config.php orm:generate-proxies app/Models/Proxies
+
+# Inspect mappings and run ad-hoc DQL
+php cli-config.php orm:info
+php cli-config.php orm:mapping:describe "App\Models\Entity\User"
+php cli-config.php orm:run-dql "SELECT u FROM App\Models\Entity\User u"
 ```
 
-## Troubleshooting
+> **Doctrine ORM 3 note.** `orm:convert-mapping` and `orm:generate-entities`
+> were removed in ORM 3 and are no longer available. Reverse-engineering a
+> database into entity classes is not part of the ORM 3 toolchain — define your
+> entities with PHP attributes (the default) or XML mapping instead.
 
-If you receive:
-
-```
-[Semantical Error] The annotation "@JMS\Serializer\Annotation\ExclusionPolicy"
-in class App\Models\Entity\Secret was never imported. Did you maybe forget to
-add a "use" statement for this annotation?
-```
-
-run:
-
-```bash
-composer dump-autoload
-```
-
-to refresh the annotation registry.
+For versioned schema migrations, install the optional
+[`doctrine/migrations`](https://www.doctrine-project.org/projects/migrations.html)
+package (listed under `suggest`) or use CodeIgniter's own migration system.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,6 +63,33 @@ existing files; choose `n` to abort safely.
 |--------|------|-------------|
 | `customTypeMappings` | `array<string, string>` | Native DBAL type → Doctrine type mappings registered on the database platform. Default: `['enum' => 'string', 'set' => 'string']`. Re-applied automatically on `Doctrine::reOpen()`. |
 
+### Extension points
+
+All of the following are additive and default to "off" (empty / `null` / `false`),
+so existing configs are unaffected.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `customTypes` | `array<string, class-string<Doctrine\DBAL\Types\Type>>` | Custom DBAL Types registered with `Type::addType()` (idempotent). Use for UUID/ULID keys, value objects, etc. Applied on construction and `reOpen()`. |
+| `sqlFilters` | `array<string, class-string<Doctrine\ORM\Query\Filter\SQLFilter>>` | Named SQL filters to register (soft-delete, multi-tenant scoping). |
+| `enabledFilters` | `list<string>` | Names from `sqlFilters` to enable automatically on every `EntityManager` (and after `reOpen()`). Filter parameters must still be set at runtime via `$em->getFilters()->getFilter($name)->setParameter(...)`. |
+| `eventListeners` | `array<string, list<class-string\|object>>` | Doctrine event listeners keyed by event name (e.g. `'onFlush'`). Class-strings are instantiated with no arguments. |
+| `eventSubscribers` | `list<class-string<Doctrine\Common\EventSubscriber>\|object>` | Doctrine event subscribers. |
+| `dbalMiddlewares` | `list<class-string<Doctrine\DBAL\Driver\Middleware>\|object>` | User DBAL middlewares (retry/logging/metrics). They wrap the driver first; the toolbar capture middleware is applied last. |
+| `defaultRepositoryClass` | `?class-string<Doctrine\ORM\EntityRepository>` | Default repository class for entities that don't declare their own. `null` keeps Doctrine's built-in repository. |
+
+### Production query logging
+
+Unlike the Debug Toolbar collector (which only renders under `CI_DEBUG`), query
+logging runs in any environment, giving production a slow-query log via a PSR-3
+logger (CodeIgniter's `logger` service by default).
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `queryLogging` | `bool` | `false` | Enable query logging via `Daycry\Doctrine\Logging\QueryLoggerMiddleware`. |
+| `slowQueryThreshold` | `float` | `0.0` | Minimum query duration (seconds) before logging. `0.0` logs every query (noisy); set e.g. `0.5` for slow-query logging only. |
+| `queryLogLevel` | `string` | `'info'` | PSR-3 level used for the log records. |
+
 ## Quick example
 
 ```php

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,6 +36,12 @@ existing files; choose `n` to abort safely.
 | `queryCache` / `resultsCache` / `metadataCache` | `bool` | `true` | Toggle each Doctrine cache backed by `Config\Cache`. |
 | `queryCacheNamespace` / `resultsCacheNamespace` / `metadataCacheNamespace` | `string` | `doctrine_queries` / `doctrine_results` / `doctrine_metadata` | Namespace prefix for each cache pool. |
 
+!!! info "Per-group isolation"
+    Cache namespaces are automatically suffixed with the database group name for
+    every **non-default** group (e.g. `doctrine_results_reporting`), so multiple
+    groups sharing one cache backend never collide on the same keys. The default
+    group keeps the unsuffixed namespaces shown above.
+
 ### Metadata driver
 
 | Option | Type | Default | Description |

--- a/docs/datatables.md
+++ b/docs/datatables.md
@@ -34,6 +34,9 @@ and end-to-end examples.
 | `withCaseInsensitive(bool $flag)` | Enable case-insensitive LIKE / equality via `lower()`. |
 | `withIndexColumn(string $col)` | Override the index column used in pagination. |
 | `withMaxFilterValues(int $max)` | Cap the values accepted by `[IN]` and `[OR]`. Throws `InvalidArgumentException` if `< 1`. Use `PHP_INT_MAX` to disable. **Default: 500**, intended as a DoS guard. |
+| `withMaxPageLength(int $max)` | Hard cap on the page size. Clamps DataTables' `length=-1` ("All") and oversized requests, which would otherwise hydrate the whole filtered table. **Default: 0** (no cap). Throws on a negative value. |
+| `withFetchJoinCollection(bool $flag)` | Whether the data Paginator fetches to-many collections via an id sub-query. **Default: true.** Set `false` for scalar/single-entity SELECTs to collapse the page fetch into a single query. |
+| `withRecordsTotal(int\|Closure $total)` | Inject or cache the unfiltered total so `getRecordsTotal()` / `getResponse()` skip the COUNT query across draws. Invalidation is the caller's responsibility. |
 | `setUseOutputWalkers(bool $flag)` | Toggle Doctrine `Paginator` output walkers. Set `false` when pagination fails with scalar-select queries (eg. *"Not all identifier properties can be found in the ResultSetMapping"*). |
 | `getData()` | Execute and return the paginated, filtered, ordered result. |
 | `getRecordsFiltered()` | Count records matching the current filters (no pagination). |
@@ -134,6 +137,25 @@ $builder->withRequestParams([
     ],
 ]);
 // Equivalent to LIKE '%[XYZ]am%' — useful to know when debugging silent matches.
+```
+
+## Performance & limits
+
+- **Cap the page size.** `withMaxPageLength(200)` clamps DataTables' "All"
+  sentinel (`length=-1`) and oversized `length` values so a single request
+  cannot hydrate the entire filtered table. Off by default (`0`) for backward
+  compatibility — set it on public/unauthenticated endpoints.
+- **Skip the unneeded fetch-join query.** For the common scalar or
+  single-entity SELECT (no to-many fetch join), `withFetchJoinCollection(false)`
+  collapses the data fetch from two queries (id sub-query + `WHERE IN`) into one.
+- **Cache the total.** `recordsTotal` rarely changes between draws. Inject it to
+  skip the COUNT query entirely:
+
+```php
+$builder
+    ->withMaxPageLength(200)
+    ->withFetchJoinCollection(false)
+    ->withRecordsTotal(fn (): int => cache()->remember('projects_total', 300, fn () => $repo->count([])));
 ```
 
 ## Best Practices

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,108 @@
+---
+hide:
+  - navigation
+  - toc
+---
+
+<div class="hero" markdown>
+
+# Daycry Doctrine
+
+**Doctrine ORM 3** integration for **CodeIgniter 4** — a configured `EntityManager`, per-group multi-database support, query/result/metadata caching and **Second-Level Cache**, a safe server-side **DataTables Builder**, a debug-toolbar collector and **Spark / ORM CLI** tooling. Backward-compatible and production-ready.
+
+[Get started :material-rocket-launch:](installation.md){ .md-button .md-button--primary }
+[DataTables :material-table:](datatables.md){ .md-button }
+[GitHub :material-github:](https://github.com/daycry/doctrine){ .md-button }
+
+</div>
+
+## Features
+
+<div class="grid cards" markdown>
+
+-   :material-database-cog:{ .lg .middle } __EntityManager, your way__
+
+    ---
+
+    Use it as a service, a helper or a plain object. `getEm()` with null-guards, `reOpen()` that actually reconnects a stale worker connection, and SSL / custom DBAL options passthrough.
+
+    [:octicons-arrow-right-24: Usage](usage.md)
+
+-   :material-table-search:{ .lg .middle } __Server-side DataTables__
+
+    ---
+
+    Filtering, ordering and pagination with safe operator parsing, whitelisted columns, page-size and filter-value caps, `fetchJoinCollection` opt-out and injectable totals.
+
+    [:octicons-arrow-right-24: DataTables](datatables.md)
+
+-   :material-magnify:{ .lg .middle } __Bracket search operators__
+
+    ---
+
+    Per-column `[%] [=] [!=] [>] [<] [IN] [OR] [><]` with case-insensitive support and strict, documented validation — `regex: true` is rejected by design.
+
+    [:octicons-arrow-right-24: Search Modes](search_modes.md)
+
+-   :material-layers-triple:{ .lg .middle } __Caching & Second-Level Cache__
+
+    ---
+
+    Query / result / metadata caches backed by `Config\Cache`, per-group namespacing, the `getFromCacheOrQuery()` cache-aside helper, and Doctrine SLC with an optional stats badge.
+
+    [:octicons-arrow-right-24: Second-Level Cache](second_level_cache.md)
+
+-   :material-database-multiple:{ .lg .middle } __Multi-database groups__
+
+    ---
+
+    Every `Config\Database` group resolves to its own cached Doctrine instance and isolated cache namespaces — and the ORM CLI can target any group with `--em=<group>`.
+
+    [:octicons-arrow-right-24: CLI Commands](cli_commands.md)
+
+-   :material-puzzle:{ .lg .middle } __Extensible by config__
+
+    ---
+
+    Register custom DBAL Types, SQL Filters (soft-delete / multi-tenant), event listeners/subscribers, DBAL middlewares and a default repository class — all re-applied on `reOpen()`.
+
+    [:octicons-arrow-right-24: Configuration](configuration.md)
+
+-   :material-bug-check:{ .lg .middle } __Debug toolbar & logging__
+
+    ---
+
+    A toolbar collector captures every DBAL query (debug only), with an SLC hit/miss/put badge — plus opt-in **PSR-3 production query logging** with a slow-query threshold.
+
+    [:octicons-arrow-right-24: Debug Toolbar](debug_toolbar.md)
+
+-   :material-console:{ .lg .middle } __Spark & ORM CLI__
+
+    ---
+
+    `doctrine:publish`, `doctrine:cache:clear`, `doctrine:validate`, `doctrine:info`, `doctrine:schema:update`, plus the full Doctrine ORM console via `cli-config.php`.
+
+    [:octicons-arrow-right-24: CLI Commands](cli_commands.md)
+
+</div>
+
+## Quick start
+
+```bash
+composer require daycry/doctrine
+php spark doctrine:publish
+```
+
+```php
+$doctrine = \Config\Services::doctrine();
+$user     = $doctrine->em->getRepository(\App\Models\Entity\User::class)->find(1);
+```
+
+See **[Installation](installation.md)** and **[Configuration](configuration.md)** to get going, or jump to the **[DataTables Builder](datatables.md)**.
+
+## Requirements
+
+- PHP **≥ 8.2**
+- CodeIgniter **^4**
+- Doctrine ORM **^3**, DBAL **^4**
+- Symfony Cache **^7**

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+mkdocs-material>=9.5,<10.0

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,70 @@
+/* ------------------------------------------------------------------ *
+ *  Daycry Doctrine — landing-page polish on top of MkDocs Material.
+ * ------------------------------------------------------------------ */
+
+/* ---- Hero ---------------------------------------------------------- */
+.hero {
+  text-align: center;
+  padding: 3.5rem 1rem 3rem;
+  margin: -1.2rem 0 2.5rem;
+  background: radial-gradient(
+    1100px 380px at 50% -12%,
+    color-mix(in srgb, var(--md-primary-fg-color) 20%, transparent),
+    transparent 70%
+  );
+  border-bottom: 1px solid var(--md-default-fg-color--lightest);
+}
+
+.md-typeset .hero h1 {
+  font-size: clamp(2.2rem, 5.5vw, 3.4rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+  margin: 0 0 0.7rem;
+  background: linear-gradient(
+    90deg,
+    var(--md-primary-fg-color),
+    color-mix(in srgb, var(--md-primary-fg-color) 50%, #22d3ee)
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.hero > p {
+  max-width: 46rem;
+  margin: 0 auto 1.6rem;
+  font-size: 1.06rem;
+  color: var(--md-default-fg-color--light);
+}
+
+.hero .md-button {
+  margin: 0.3rem 0.3rem;
+  border-radius: 2rem;
+}
+
+/* ---- Feature cards: lift + accent on hover ------------------------- */
+.md-typeset .grid.cards > :is(ul, ol) > li,
+.md-typeset .grid.cards > .card {
+  border-radius: 0.7rem;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+}
+
+.md-typeset .grid.cards > :is(ul, ol) > li:hover,
+.md-typeset .grid.cards > .card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  border-color: var(--md-primary-fg-color);
+}
+
+/* Card heading icons in the brand colour. */
+.md-typeset .grid.cards .lg.middle,
+.md-typeset .grid.cards .twemoji.lg {
+  color: var(--md-primary-fg-color);
+}
+
+/* ---- Small global polish ------------------------------------------ */
+/* Slightly rounder code blocks to match the cards. */
+.md-typeset pre > code {
+  border-radius: 0.5rem;
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -134,7 +134,9 @@ function getFromCacheOrQuery(
   );
   ```
 
-PSR-6 reserves `{}()/\@:` in cache keys — avoid them.
+PSR-6 reserved characters (`{}()/\@:`) in the key are normalised automatically
+(sanitised and disambiguated with a short hash of the original), so any key
+string is accepted.
 
 ## Second-Level Cache Statistics
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,135 @@
+site_name: Daycry Doctrine
+site_description: Doctrine ORM 3 integration for CodeIgniter 4 — EntityManager, multi-DB groups, caching & Second-Level Cache, server-side DataTables, debug toolbar and a Spark/ORM CLI.
+site_author: Daycry
+site_url: https://daycry.github.io/doctrine/
+copyright: Copyright &copy; 2025 Daycry
+
+repo_url: https://github.com/daycry/doctrine
+repo_name: daycry/doctrine
+edit_uri: edit/development/docs/
+
+docs_dir: docs
+
+theme:
+  name: material
+  language: en
+  icon:
+    repo: fontawesome/brands/github
+  font:
+    text: Inter
+    code: JetBrains Mono
+  features:
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.sections
+    - navigation.top
+    - navigation.instant
+    - navigation.instant.progress
+    - navigation.tracking
+    - navigation.indexes
+    - toc.follow
+    - search.suggest
+    - search.highlight
+    - search.share
+    - content.code.copy
+    - content.code.annotate
+    - content.tooltips
+    - content.action.edit
+    - content.action.view
+    - navigation.footer
+    - navigation.path
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+
+plugins:
+  - search
+
+markdown_extensions:
+  - abbr
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+      slugify: !!python/object/apply:pymdownx.slugs.slugify
+        kwds:
+          case: lower
+  - pymdownx.betterem
+  - pymdownx.caret
+  - pymdownx.mark
+  - pymdownx.tilde
+  - pymdownx.details
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+      # Doc PHP snippets sometimes omit the opening `<?php` tag; run the PHP
+      # lexer in inline mode so bare PHP still highlights correctly.
+      extend_pygments_lang:
+        - name: php
+          lang: php
+          options:
+            startinline: true
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+
+# Fail `mkdocs build --strict` on any broken internal link or anchor.
+validation:
+  omitted_files: warn
+  absolute_links: warn
+  unrecognized_links: warn
+  anchors: warn
+
+# The docs folder README is an index for GitHub, not a site page.
+exclude_docs: |
+  README.md
+
+extra_css:
+  - stylesheets/extra.css
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/daycry/doctrine
+    - icon: fontawesome/brands/php
+      link: https://packagist.org/packages/daycry/doctrine
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Installation: installation.md
+      - Configuration: configuration.md
+      - Usage: usage.md
+  - DataTables:
+      - Builder: datatables.md
+      - Search Modes: search_modes.md
+  - Caching:
+      - Second-Level Cache: second_level_cache.md
+      - SLC Statistics: second_level_cache_stats.md
+  - Tooling:
+      - CLI Commands: cli_commands.md
+      - Debug Toolbar: debug_toolbar.md

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -63,6 +63,10 @@ parameters:
         - identifier: method.dynamicName
           path: src/Debug/Toolbar/Collectors/DoctrineQueryMiddleware.php
 
+        # Same intentional __call() forwarding in the query-logging middleware
+        - identifier: method.dynamicName
+          path: src/Logging/QueryLoggerMiddleware.php
+
         # getSharedInstance() return type is mixed — @var annotation ensures proper type narrowing
         - identifier: varTag.type
           path: src/Config/Services.php

--- a/src/Commands/DoctrineCacheClear.php
+++ b/src/Commands/DoctrineCacheClear.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Daycry\Doctrine\Commands;
+
+use CodeIgniter\CLI\CLI;
+use Daycry\Doctrine\Config\Services;
+
+/**
+ * Clears the Doctrine query, result and metadata caches for a database group.
+ */
+class DoctrineCacheClear extends DoctrineCommand
+{
+    protected $name        = 'doctrine:cache:clear';
+    protected $description = 'Clear the Doctrine query, result and metadata caches.';
+    protected $usage       = 'doctrine:cache:clear [--group <db_group>]';
+    protected $arguments   = [];
+    protected $options     = [
+        '--group' => 'Database group whose caches to clear (default: default group).',
+    ];
+
+    /**
+     * @param array<int|string, string|null> $params
+     */
+    public function run(array $params): int
+    {
+        $config = Services::doctrine(true, $this->dbGroup($params))->getEm()->getConfiguration();
+
+        $pools = [
+            'query'    => $config->getQueryCache(),
+            'result'   => $config->getResultCache(),
+            'metadata' => $config->getMetadataCache(),
+        ];
+
+        $cleared = [];
+
+        foreach ($pools as $label => $pool) {
+            if ($pool !== null) {
+                $pool->clear();
+                $cleared[] = $label;
+            }
+        }
+
+        CLI::write('Cleared Doctrine caches: ' . ($cleared === [] ? 'none configured' : implode(', ', $cleared)), 'green');
+
+        return 0;
+    }
+}

--- a/src/Commands/DoctrineCommand.php
+++ b/src/Commands/DoctrineCommand.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Daycry\Doctrine\Commands;
+
+use CodeIgniter\CLI\BaseCommand;
+use CodeIgniter\CLI\CLI;
+use Daycry\Doctrine\Config\Services;
+use Doctrine\ORM\Tools\Console\EntityManagerProvider\SingleManagerProvider;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+/**
+ * Base class for the Spark wrappers around the Doctrine ORM console commands.
+ * Resolves the EntityManager for the requested database group (via the
+ * `--group` option) and runs an ORM console command through a throwaway Symfony
+ * Console Application, forwarding its output to the CodeIgniter CLI.
+ */
+abstract class DoctrineCommand extends BaseCommand
+{
+    protected $group = 'Doctrine';
+
+    /**
+     * Resolve the database group from the `--group` option (null = default).
+     *
+     * @param array<int|string, string|null> $params
+     */
+    protected function dbGroup(array $params): ?string
+    {
+        $group = $params['group'] ?? CLI::getOption('group');
+
+        return is_string($group) && $group !== '' ? $group : null;
+    }
+
+    /**
+     * Build a single-manager provider for the given database group.
+     */
+    protected function provider(?string $dbGroup): SingleManagerProvider
+    {
+        return new SingleManagerProvider(Services::doctrine(true, $dbGroup)->getEm());
+    }
+
+    /**
+     * Run an ORM console command and stream its output to the CLI.
+     *
+     * @param array<string, bool|string> $args extra Console input (e.g. ['--force' => true])
+     */
+    protected function runOrmCommand(Command $command, string $name, array $args = []): int
+    {
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->addCommand($command);
+
+        $output = new BufferedOutput();
+        $exit   = $application->run(new ArrayInput(['command' => $name] + $args), $output);
+
+        CLI::write(rtrim($output->fetch()));
+
+        return $exit;
+    }
+}

--- a/src/Commands/DoctrineInfo.php
+++ b/src/Commands/DoctrineInfo.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Daycry\Doctrine\Commands;
+
+use Doctrine\ORM\Tools\Console\Command\InfoCommand;
+
+/**
+ * Spark wrapper for `orm:info`: lists the mapped entities and reports mapping
+ * errors.
+ */
+class DoctrineInfo extends DoctrineCommand
+{
+    protected $name        = 'doctrine:info';
+    protected $description = 'Show mapped entities for a database group.';
+    protected $usage       = 'doctrine:info [--group <db_group>]';
+    protected $arguments   = [];
+    protected $options     = [
+        '--group' => 'Database group (default: default group).',
+    ];
+
+    /**
+     * @param array<int|string, string|null> $params
+     */
+    public function run(array $params): int
+    {
+        return $this->runOrmCommand(
+            new InfoCommand($this->provider($this->dbGroup($params))),
+            'orm:info',
+        );
+    }
+}

--- a/src/Commands/DoctrineSchemaUpdate.php
+++ b/src/Commands/DoctrineSchemaUpdate.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Daycry\Doctrine\Commands;
+
+use CodeIgniter\CLI\CLI;
+use Doctrine\ORM\Tools\Console\Command\SchemaTool\UpdateCommand;
+
+/**
+ * Spark wrapper for `orm:schema-tool:update`. Without --force it only dumps the
+ * SQL that would bring the database schema in sync with the mappings.
+ */
+class DoctrineSchemaUpdate extends DoctrineCommand
+{
+    protected $name        = 'doctrine:schema:update';
+    protected $description = 'Update the database schema to match the entity mappings.';
+    protected $usage       = 'doctrine:schema:update [--force] [--dump-sql] [--group <db_group>]';
+    protected $arguments   = [];
+    protected $options     = [
+        '--force'    => 'Apply the schema changes to the database.',
+        '--dump-sql' => 'Print the SQL that would be executed (default when --force is absent).',
+        '--group'    => 'Database group (default: default group).',
+    ];
+
+    /**
+     * @param array<int|string, string|null> $params
+     */
+    public function run(array $params): int
+    {
+        $force   = array_key_exists('force', $params)    || CLI::getOption('force') !== null;
+        $dumpSql = array_key_exists('dump-sql', $params) || CLI::getOption('dump-sql') !== null;
+
+        $args = [];
+        if ($force) {
+            $args['--force'] = true;
+        }
+        // orm:schema-tool:update requires one of --force/--dump-sql; default to a
+        // safe, non-destructive dry run when neither is given.
+        if ($dumpSql || ! $force) {
+            $args['--dump-sql'] = true;
+        }
+
+        return $this->runOrmCommand(
+            new UpdateCommand($this->provider($this->dbGroup($params))),
+            'orm:schema-tool:update',
+            $args,
+        );
+    }
+}

--- a/src/Commands/DoctrineValidate.php
+++ b/src/Commands/DoctrineValidate.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Daycry\Doctrine\Commands;
+
+use Doctrine\ORM\Tools\Console\Command\ValidateSchemaCommand;
+
+/**
+ * Spark wrapper for `orm:validate-schema`: validates the mapping and that the
+ * database schema is in sync with it.
+ */
+class DoctrineValidate extends DoctrineCommand
+{
+    protected $name        = 'doctrine:validate';
+    protected $description = 'Validate the Doctrine mapping files and database schema.';
+    protected $usage       = 'doctrine:validate [--group <db_group>]';
+    protected $arguments   = [];
+    protected $options     = [
+        '--group' => 'Database group (default: default group).',
+    ];
+
+    /**
+     * @param array<int|string, string|null> $params
+     */
+    public function run(array $params): int
+    {
+        return $this->runOrmCommand(
+            new ValidateSchemaCommand($this->provider($this->dbGroup($params))),
+            'orm:validate-schema',
+        );
+    }
+}

--- a/src/Config/Doctrine.php
+++ b/src/Config/Doctrine.php
@@ -6,7 +6,9 @@ namespace Daycry\Doctrine\Config;
 
 use CodeIgniter\Config\BaseConfig;
 use Doctrine\Common\EventSubscriber;
+use Doctrine\DBAL\Driver\Middleware;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Query\Filter\SQLFilter;
 use DoctrineExtensions\Query\Mysql\AnyValue;
 use DoctrineExtensions\Query\Mysql\Binary;
@@ -347,4 +349,44 @@ class Doctrine extends BaseConfig
      * @var list<class-string<EventSubscriber>|EventSubscriber>
      */
     public array $eventSubscribers = [];
+
+    /**
+     * User-defined DBAL middlewares to compose with the toolbar middleware
+     * (retry, logging, metrics, …). Each entry is a class-string or instance of
+     * Doctrine\DBAL\Driver\Middleware. Listed middlewares wrap the driver first
+     * (outermost); the toolbar capture middleware, when enabled, is applied last
+     * so it sees the final SQL closest to the driver.
+     *
+     * @var list<class-string<Middleware>|Middleware>
+     */
+    public array $dbalMiddlewares = [];
+
+    /**
+     * Default repository class used for every entity that does not declare its
+     * own via #[ORM\Entity(repositoryClass: ...)]. Must extend
+     * Doctrine\ORM\EntityRepository. null keeps Doctrine's built-in repository.
+     *
+     * @var class-string<EntityRepository<object>>|null
+     */
+    public ?string $defaultRepositoryClass = null;
+
+    /**
+     * Enable production query logging via a PSR-3 logger (CodeIgniter's logger
+     * by default). Unlike the Debug Toolbar collector — which only renders under
+     * CI_DEBUG — this logs in any environment, making slow queries observable in
+     * production. Off by default.
+     */
+    public bool $queryLogging = false;
+
+    /**
+     * Minimum query duration, in seconds, before a query is logged when
+     * $queryLogging is enabled. 0.0 logs every query (noisy — intended for
+     * debugging); set e.g. 0.5 to log only queries slower than 500 ms.
+     */
+    public float $slowQueryThreshold = 0.0;
+
+    /**
+     * PSR-3 log level used for query logging (e.g. 'debug', 'info', 'warning').
+     */
+    public string $queryLogLevel = 'info';
 }

--- a/src/Config/Doctrine.php
+++ b/src/Config/Doctrine.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Daycry\Doctrine\Config;
 
 use CodeIgniter\Config\BaseConfig;
+use Doctrine\Common\EventSubscriber;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\Query\Filter\SQLFilter;
 use DoctrineExtensions\Query\Mysql\AnyValue;
 use DoctrineExtensions\Query\Mysql\Binary;
 use DoctrineExtensions\Query\Mysql\BitCount;
@@ -290,4 +293,58 @@ class Doctrine extends BaseConfig
         'enum' => 'string',
         'set'  => 'string',
     ];
+
+    /**
+     * Custom DBAL Types to register via Doctrine\DBAL\Types\Type::addType().
+     * Registration is idempotent (guarded by Type::hasType()) and applied on
+     * construction and reOpen().
+     *
+     * Key = type name referenced by entities / customTypeMappings,
+     * value = a Doctrine\DBAL\Types\Type subclass.
+     *
+     * Example: ['uuid' => \Ramsey\Uuid\Doctrine\UuidType::class]
+     *
+     * @var array<string, class-string<Type>>
+     */
+    public array $customTypes = [];
+
+    /**
+     * Doctrine SQL Filters to register on the EntityManager configuration
+     * (soft-delete, multi-tenant scoping, …).
+     *
+     * Key = filter name, value = a Doctrine\ORM\Query\Filter\SQLFilter subclass.
+     *
+     * @var array<string, class-string<SQLFilter>>
+     */
+    public array $sqlFilters = [];
+
+    /**
+     * Names of SQL filters (declared in $sqlFilters) to enable automatically on
+     * every EntityManager, including after reOpen(). Parameters that a filter
+     * needs at runtime must still be set by the application via
+     * $em->getFilters()->getFilter($name)->setParameter(...).
+     *
+     * @var list<string>
+     */
+    public array $enabledFilters = [];
+
+    /**
+     * Doctrine event listeners, keyed by event name (e.g. 'prePersist',
+     * 'postLoad', 'onFlush'). Each value is a list of listener class-strings or
+     * ready-made listener instances. Class-strings are instantiated with no
+     * constructor arguments.
+     *
+     * Example: ['onFlush' => [\App\Doctrine\AuditListener::class]]
+     *
+     * @var array<string, list<class-string|object>>
+     */
+    public array $eventListeners = [];
+
+    /**
+     * Doctrine event subscribers (implementing Doctrine\Common\EventSubscriber).
+     * Each entry is a class-string or a ready-made instance.
+     *
+     * @var list<class-string<EventSubscriber>|EventSubscriber>
+     */
+    public array $eventSubscribers = [];
 }

--- a/src/DataTables/Builder.php
+++ b/src/DataTables/Builder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Daycry\Doctrine\DataTables;
 
+use Closure;
 use CodeIgniter\Exceptions\InvalidArgumentException;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\ORM\QueryBuilder as ORMQueryBuilder;
@@ -85,6 +86,22 @@ class Builder
     protected int $maxPageLength = 0;
 
     /**
+     * Whether the data Paginator fetches to-many collections via an id sub-query
+     * (`fetchJoinCollection`). Defaults to true (Doctrine's safe default). Set to
+     * false when the query has no to-many fetch join to collapse the page fetch
+     * from two queries (id sub-query + WHERE-IN) into one. Count queries are
+     * unaffected by this flag.
+     */
+    protected bool $fetchJoinCollection = true;
+
+    /**
+     * Optional precomputed unfiltered total. When set (an int or a Closure
+     * returning an int), getRecordsTotal()/getResponse() return it instead of
+     * issuing a COUNT query — useful to cache an expensive total across draws.
+     */
+    protected Closure|int|null $recordsTotal = null;
+
+    /**
      * Static factory for fluent usage.
      */
     public static function create(): self
@@ -140,6 +157,30 @@ class Builder
     }
 
     /**
+     * Set whether the paginated data fetch uses `fetchJoinCollection`.
+     * Leave true (default) for queries that fetch-join a to-many association;
+     * set false for the common scalar/single-entity SELECT to save one query.
+     */
+    public function withFetchJoinCollection(bool $fetchJoinCollection): static
+    {
+        $this->fetchJoinCollection = $fetchJoinCollection;
+
+        return $this;
+    }
+
+    /**
+     * Provide a precomputed unfiltered total (int or a Closure returning int) so
+     * getRecordsTotal()/getResponse() skip the COUNT query. Invalidation is the
+     * caller's responsibility.
+     */
+    public function withRecordsTotal(Closure|int $recordsTotal): static
+    {
+        $this->recordsTotal = $recordsTotal;
+
+        return $this;
+    }
+
+    /**
      * Returns paginated, filtered, and ordered data for DataTables.
      *
      * @return list<object>
@@ -153,7 +194,7 @@ class Builder
         $columns = $this->requestParams['columns'];
         $this->applyOrdering($query, $columns);
         $this->applyPagination($query);
-        $paginator = new Paginator($query, $fetchJoinCollection = true);
+        $paginator = new Paginator($query, $this->fetchJoinCollection);
         $paginator->setUseOutputWalkers($this->useOutputWalkers ?? true);
         $result = [];
 
@@ -391,12 +432,29 @@ class Builder
      */
     public function getRecordsTotal(): int
     {
+        $injected = $this->resolveInjectedRecordsTotal();
+        if ($injected !== null) {
+            return $injected;
+        }
+
         $this->validate();
         $query     = clone $this->queryBuilder;
         $paginator = new Paginator($query, $fetchJoinCollection = true);
         $paginator->setUseOutputWalkers($this->useOutputWalkers ?? true);
 
         return $paginator->count();
+    }
+
+    /**
+     * Resolve the injected unfiltered total, or null when none was provided.
+     */
+    private function resolveInjectedRecordsTotal(): ?int
+    {
+        if ($this->recordsTotal === null) {
+            return null;
+        }
+
+        return (int) ($this->recordsTotal instanceof Closure ? ($this->recordsTotal)() : $this->recordsTotal);
     }
 
     /**
@@ -414,7 +472,7 @@ class Builder
         $dataQuery = clone $filteredQuery;
         $this->applyOrdering($dataQuery, $columns);
         $this->applyPagination($dataQuery);
-        $dataPaginator = new Paginator($dataQuery, true);
+        $dataPaginator = new Paginator($dataQuery, $this->fetchJoinCollection);
         $dataPaginator->setUseOutputWalkers($this->useOutputWalkers ?? true);
         $data = [];
 
@@ -426,16 +484,21 @@ class Builder
         $filteredPaginator = new Paginator($filteredQuery, true);
         $filteredPaginator->setUseOutputWalkers($this->useOutputWalkers ?? true);
 
-        // Total count (unfiltered)
-        $totalQuery     = clone $this->queryBuilder;
-        $totalPaginator = new Paginator($totalQuery, true);
-        $totalPaginator->setUseOutputWalkers($this->useOutputWalkers ?? true);
+        // Total count (unfiltered) — use the injected/cached total when provided,
+        // otherwise compute it via a Paginator.
+        $recordsTotal = $this->resolveInjectedRecordsTotal();
+        if ($recordsTotal === null) {
+            $totalQuery     = clone $this->queryBuilder;
+            $totalPaginator = new Paginator($totalQuery, true);
+            $totalPaginator->setUseOutputWalkers($this->useOutputWalkers ?? true);
+            $recordsTotal = $totalPaginator->count();
+        }
 
         return [
             'data'            => $data,
             'draw'            => $this->requestParams['draw'] ?? 0,
             'recordsFiltered' => $filteredPaginator->count(),
-            'recordsTotal'    => $totalPaginator->count(),
+            'recordsTotal'    => $recordsTotal,
         ];
     }
 

--- a/src/DataTables/Builder.php
+++ b/src/DataTables/Builder.php
@@ -77,6 +77,14 @@ class Builder
     protected int $maxFilterValues = 500;
 
     /**
+     * Hard cap on the page size (DataTables `length`). When greater than 0, any
+     * request asking for more rows than this — including DataTables' "All"
+     * sentinel `length=-1`, which otherwise produces an unbounded result set —
+     * is clamped to this value. 0 (default) keeps the legacy behaviour (no cap).
+     */
+    protected int $maxPageLength = 0;
+
+    /**
      * Static factory for fluent usage.
      */
     public static function create(): self
@@ -109,6 +117,24 @@ class Builder
         }
 
         $this->maxFilterValues = $maxFilterValues;
+
+        return $this;
+    }
+
+    /**
+     * Set a hard upper bound on the page size returned to the client.
+     *
+     * Protects against resource exhaustion from `length=-1` ("All") or an
+     * arbitrarily large `length`, which would otherwise hydrate the entire
+     * filtered table. Pass 0 to disable the cap (legacy behaviour).
+     */
+    public function withMaxPageLength(int $maxPageLength): static
+    {
+        if ($maxPageLength < 0) {
+            throw new InvalidArgumentException('maxPageLength must be 0 (disabled) or a positive integer.');
+        }
+
+        $this->maxPageLength = $maxPageLength;
 
         return $this;
     }
@@ -273,7 +299,10 @@ class Builder
                         $orX = $query->expr()->orX();
 
                         for ($j = 0; $j < count($valueArr); $j++) {
-                            $orX->add($query->expr()->like($fieldName, ":filter_{$i}_{$j}"));
+                            // Honor caseInsensitive: $searchColumn is already lower()-wrapped
+                            // when the flag is on; wrap each placeholder to match.
+                            $orPlaceholder = $this->caseInsensitive ? "lower(:filter_{$i}_{$j})" : ":filter_{$i}_{$j}";
+                            $orX->add($query->expr()->like($searchColumn, $orPlaceholder));
                         }
                         $andX->add($orX);
 
@@ -508,8 +537,18 @@ class Builder
             $order = $this->requestParams['order'];
 
             foreach ($order as $sort) {
-                $column    = $columns[(int) ($sort['column'])];
-                $fieldName = $this->resolveFieldName($column[$this->columnField] ?? '', (int) ($sort['column']));
+                // Skip entries whose client-supplied column index is missing or
+                // out of range, instead of warning on an undefined array key.
+                if (! isset($sort['column'])) {
+                    continue;
+                }
+                $columnIndex = (int) $sort['column'];
+                if (! array_key_exists($columnIndex, $columns)) {
+                    continue;
+                }
+
+                $column    = $columns[$columnIndex];
+                $fieldName = $this->resolveFieldName($column[$this->columnField] ?? '', $columnIndex);
                 $dir       = strtoupper($sort['dir'] ?? 'ASC');
                 $dir       = in_array($dir, ['ASC', 'DESC'], true) ? $dir : 'ASC';
 
@@ -529,11 +568,17 @@ class Builder
         if (array_key_exists('start', $this->requestParams)) {
             $query->setFirstResult((int) ($this->requestParams['start']));
         }
-        if (array_key_exists('length', $this->requestParams)) {
-            $length = (int) ($this->requestParams['length']);
-            if ($length > 0) {
-                $query->setMaxResults($length);
-            }
+
+        $length = array_key_exists('length', $this->requestParams)
+            ? (int) ($this->requestParams['length'])
+            : 0;
+
+        if ($this->maxPageLength > 0) {
+            // Clamp unbounded ("All"/length<=0) or oversized requests to the cap.
+            $effective = ($length <= 0 || $length > $this->maxPageLength) ? $this->maxPageLength : $length;
+            $query->setMaxResults($effective);
+        } elseif ($length > 0) {
+            $query->setMaxResults($length);
         }
     }
 

--- a/src/Doctrine.php
+++ b/src/Doctrine.php
@@ -79,28 +79,37 @@ class Doctrine
             }
         }
 
+        /** @var Database $dbConfig */
+        $dbConfig = config('Database');
+        if ($dbGroup === null) {
+            $dbGroup = (ENVIRONMENT === 'testing') ? 'tests' : $dbConfig->defaultGroup;
+        }
+        // Suffix cache namespaces with the (non-default) DB group so that multiple
+        // groups sharing one cache backend never collide on the same keys.
+        $cacheGroupSuffix = $dbGroup === $dbConfig->defaultGroup ? '' : '_' . strtolower($dbGroup);
+
         switch ($cacheConfig->handler) {
             case 'file':
                 $this->sharedFilesystemPath = $cacheConfig->file['storePath'] . DIRECTORY_SEPARATOR . 'doctrine';
-                $cacheQuery                 = new PhpFilesAdapter($cacheConfig->prefix . $doctrineConfig->queryCacheNamespace, $cacheConfig->ttl, $this->sharedFilesystemPath);
-                $cacheResult                = new PhpFilesAdapter($cacheConfig->prefix . $doctrineConfig->resultsCacheNamespace, $cacheConfig->ttl, $this->sharedFilesystemPath);
-                $cacheMetadata              = new PhpFilesAdapter($cacheConfig->prefix . $doctrineConfig->metadataCacheNamespace, $cacheConfig->ttl, $this->sharedFilesystemPath);
+                $cacheQuery                 = new PhpFilesAdapter($cacheConfig->prefix . $doctrineConfig->queryCacheNamespace . $cacheGroupSuffix, $cacheConfig->ttl, $this->sharedFilesystemPath);
+                $cacheResult                = new PhpFilesAdapter($cacheConfig->prefix . $doctrineConfig->resultsCacheNamespace . $cacheGroupSuffix, $cacheConfig->ttl, $this->sharedFilesystemPath);
+                $cacheMetadata              = new PhpFilesAdapter($cacheConfig->prefix . $doctrineConfig->metadataCacheNamespace . $cacheGroupSuffix, $cacheConfig->ttl, $this->sharedFilesystemPath);
                 break;
 
             case 'redis':
                 $redisLib                = new Redis($cacheConfig);
                 $this->sharedRedisClient = $redisLib->getInstance();
-                $cacheQuery              = new RedisAdapter($this->sharedRedisClient, $cacheConfig->prefix . $doctrineConfig->queryCacheNamespace, $cacheConfig->ttl);
-                $cacheResult             = new RedisAdapter($this->sharedRedisClient, $cacheConfig->prefix . $doctrineConfig->resultsCacheNamespace, $cacheConfig->ttl);
-                $cacheMetadata           = new RedisAdapter($this->sharedRedisClient, $cacheConfig->prefix . $doctrineConfig->metadataCacheNamespace, $cacheConfig->ttl);
+                $cacheQuery              = new RedisAdapter($this->sharedRedisClient, $cacheConfig->prefix . $doctrineConfig->queryCacheNamespace . $cacheGroupSuffix, $cacheConfig->ttl);
+                $cacheResult             = new RedisAdapter($this->sharedRedisClient, $cacheConfig->prefix . $doctrineConfig->resultsCacheNamespace . $cacheGroupSuffix, $cacheConfig->ttl);
+                $cacheMetadata           = new RedisAdapter($this->sharedRedisClient, $cacheConfig->prefix . $doctrineConfig->metadataCacheNamespace . $cacheGroupSuffix, $cacheConfig->ttl);
                 break;
 
             case 'memcached':
                 $memcachedLib                = new Memcached($cacheConfig);
                 $this->sharedMemcachedClient = $memcachedLib->getInstance();
-                $cacheQuery                  = new MemcachedAdapter($this->sharedMemcachedClient, $cacheConfig->prefix . $doctrineConfig->queryCacheNamespace, $cacheConfig->ttl);
-                $cacheResult                 = new MemcachedAdapter($this->sharedMemcachedClient, $cacheConfig->prefix . $doctrineConfig->resultsCacheNamespace, $cacheConfig->ttl);
-                $cacheMetadata               = new MemcachedAdapter($this->sharedMemcachedClient, $cacheConfig->prefix . $doctrineConfig->metadataCacheNamespace, $cacheConfig->ttl);
+                $cacheQuery                  = new MemcachedAdapter($this->sharedMemcachedClient, $cacheConfig->prefix . $doctrineConfig->queryCacheNamespace . $cacheGroupSuffix, $cacheConfig->ttl);
+                $cacheResult                 = new MemcachedAdapter($this->sharedMemcachedClient, $cacheConfig->prefix . $doctrineConfig->resultsCacheNamespace . $cacheGroupSuffix, $cacheConfig->ttl);
+                $cacheMetadata               = new MemcachedAdapter($this->sharedMemcachedClient, $cacheConfig->prefix . $doctrineConfig->metadataCacheNamespace . $cacheGroupSuffix, $cacheConfig->ttl);
                 break;
 
             default:
@@ -147,7 +156,7 @@ class Doctrine
                 60,
             );
 
-            $psr6Pool = $this->createSecondLevelCachePool($cacheConfig, (int) $slcTtl, $doctrineConfig);
+            $psr6Pool = $this->createSecondLevelCachePool($cacheConfig, (int) $slcTtl, $cacheGroupSuffix);
 
             $slcConfig = new ORMCacheConfiguration();
             $slcConfig->setRegionsConfiguration($regionsConfig);
@@ -227,12 +236,7 @@ class Doctrine
             $dbalConfig->setMiddlewares($middlewares);
         }
 
-        /** @var Database $dbConfig */
-        $dbConfig = config('Database');
-        if ($dbGroup === null) {
-            $dbGroup = (ENVIRONMENT === 'testing') ? 'tests' : $dbConfig->defaultGroup;
-        }
-        // Database connection information
+        // Database connection information ($dbGroup and $dbConfig resolved above).
         $connectionOptions = $this->convertDbConfig($dbConfig->{$dbGroup});
         $connection        = DriverManager::getConnection($connectionOptions, $dbalConfig);
         // Create EntityManager con la conexión original (middleware ya captura queries)
@@ -388,7 +392,10 @@ class Doctrine
         if (! empty($db->DSN)) {
             $driverMapper = ['MySQLi' => 'mysqli', 'Postgre' => 'pgsql', 'OCI8' => 'oci8', 'SQLSRV' => 'sqlsrv', 'SQLite3' => 'sqlite3'];
             if (str_contains((string) $db->DSN, 'SQLite')) {
-                $db->DSN = strtolower((string) $db->DSN);
+                // Lower-case only the scheme (everything before the first ':'); the
+                // rest of the DSN — notably a case-sensitive SQLite file path — must
+                // be preserved verbatim.
+                $db->DSN = preg_replace_callback('~^[^:]+~', static fn (array $m): string => strtolower($m[0]), (string) $db->DSN);
             }
             $dsnParser         = new DsnParser($driverMapper);
             $connectionOptions = $dsnParser->parse($db->DSN);
@@ -447,13 +454,13 @@ class Doctrine
     /**
      * Create PSR-6 cache pool for Doctrine SLC based on configured adapter.
      */
-    protected function createSecondLevelCachePool(Cache $cacheConfig, int $ttl, ?DoctrineConfig $doctrineConfig = null): Psr6AdapterInterface
+    protected function createSecondLevelCachePool(Cache $cacheConfig, int $ttl, string $groupSuffix = ''): Psr6AdapterInterface
     {
         switch ($cacheConfig->handler) {
             case 'file':
                 $dir = $this->sharedFilesystemPath ?? ($cacheConfig->file['storePath'] . DIRECTORY_SEPARATOR . 'doctrine');
 
-                return new PhpFilesAdapter($cacheConfig->prefix . 'doctrine_slc', $ttl, $dir);
+                return new PhpFilesAdapter($cacheConfig->prefix . 'doctrine_slc' . $groupSuffix, $ttl, $dir);
 
             case 'redis':
                 $client = $this->sharedRedisClient;
@@ -463,7 +470,7 @@ class Doctrine
                     $this->sharedRedisClient = $client;
                 }
 
-                return new RedisAdapter($client, $cacheConfig->prefix . 'doctrine_slc', $ttl);
+                return new RedisAdapter($client, $cacheConfig->prefix . 'doctrine_slc' . $groupSuffix, $ttl);
 
             case 'memcached':
                 $client = $this->sharedMemcachedClient;
@@ -473,7 +480,7 @@ class Doctrine
                     $this->sharedMemcachedClient = $client;
                 }
 
-                return new MemcachedAdapter($client, $cacheConfig->prefix . 'doctrine_slc', $ttl);
+                return new MemcachedAdapter($client, $cacheConfig->prefix . 'doctrine_slc' . $groupSuffix, $ttl);
 
             case 'array':
             default:

--- a/src/Doctrine.php
+++ b/src/Doctrine.php
@@ -13,8 +13,10 @@ use Daycry\Doctrine\Config\Services;
 use Daycry\Doctrine\Debug\Toolbar\Collectors\DoctrineQueryMiddleware;
 use Daycry\Doctrine\Libraries\Memcached;
 use Daycry\Doctrine\Libraries\Redis;
+use Doctrine\Common\EventManager;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Tools\DsnParser;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Cache\CacheConfiguration as ORMCacheConfiguration;
 use Doctrine\ORM\Cache\DefaultCacheFactory;
 use Doctrine\ORM\Cache\Logging\StatisticsCacheLogger;
@@ -182,6 +184,11 @@ class Doctrine
             $config->addCustomStringFunction($name, $class);
         }
 
+        // Register SQL Filters (soft-delete, multi-tenant, …) on the configuration.
+        foreach ($doctrineConfig->sqlFilters as $name => $class) {
+            $config->addFilter($name, $class);
+        }
+
         // Collector and middleware integration: capture every DBAL query for the toolbar.
         // Only wired when query instrumentation is enabled (i.e. CI_DEBUG): in production
         // the toolbar never renders, so wrapping every statement is pure dead weight.
@@ -201,9 +208,10 @@ class Doctrine
         $connectionOptions = $this->convertDbConfig($dbConfig->{$dbGroup});
         $connection        = DriverManager::getConnection($connectionOptions, $dbalConfig);
         // Create EntityManager con la conexión original (middleware ya captura queries)
-        $this->em = new EntityManager($connection, $config);
+        $this->em = new EntityManager($connection, $config, $this->buildEventManager($doctrineConfig));
 
         $this->registerTypeMappings($doctrineConfig);
+        $this->enableConfiguredFilters($doctrineConfig);
     }
 
     /**
@@ -253,8 +261,60 @@ class Doctrine
             $connection->close();
         }
 
-        $this->em = new EntityManager($connection, $em->getConfiguration());
-        $this->registerTypeMappings(config('Doctrine'));
+        /** @var DoctrineConfig $doctrineConfig */
+        $doctrineConfig = config('Doctrine');
+        $this->em       = new EntityManager($connection, $em->getConfiguration(), $this->buildEventManager($doctrineConfig));
+        $this->registerTypeMappings($doctrineConfig);
+        $this->enableConfiguredFilters($doctrineConfig);
+    }
+
+    /**
+     * Build an EventManager from the configured listeners/subscribers, or null
+     * when none are configured (so the EntityManager keeps its default).
+     * Class-strings are instantiated with no constructor arguments; ready-made
+     * instances are used as-is.
+     */
+    protected function buildEventManager(DoctrineConfig $doctrineConfig): ?EventManager
+    {
+        if ($doctrineConfig->eventListeners === [] && $doctrineConfig->eventSubscribers === []) {
+            return null;
+        }
+
+        $eventManager = new EventManager();
+
+        foreach ($doctrineConfig->eventListeners as $event => $listeners) {
+            foreach ($listeners as $listener) {
+                $eventManager->addEventListener($event, is_string($listener) ? new $listener() : $listener);
+            }
+        }
+
+        foreach ($doctrineConfig->eventSubscribers as $subscriber) {
+            $eventManager->addEventSubscriber(is_string($subscriber) ? new $subscriber() : $subscriber);
+        }
+
+        return $eventManager;
+    }
+
+    /**
+     * Enable the SQL filters listed in Config\Doctrine::$enabledFilters on the
+     * current EntityManager. FilterCollection is per-EntityManager, so this must
+     * run on construction and again after reOpen() rebuilds the EM.
+     */
+    protected function enableConfiguredFilters(DoctrineConfig $doctrineConfig): void
+    {
+        if ($doctrineConfig->enabledFilters === []) {
+            return;
+        }
+
+        $filters = $this->getEm()->getFilters();
+
+        foreach ($doctrineConfig->enabledFilters as $name) {
+            // Only enable filters that were actually registered, to avoid a
+            // misconfigured name throwing during construction.
+            if (array_key_exists($name, $doctrineConfig->sqlFilters)) {
+                $filters->enable($name);
+            }
+        }
     }
 
     /**
@@ -262,6 +322,13 @@ class Doctrine
      */
     protected function registerTypeMappings(DoctrineConfig $doctrineConfig): void
     {
+        // Register custom DBAL Types first (process-global, idempotent).
+        foreach ($doctrineConfig->customTypes as $name => $class) {
+            if (! Type::hasType($name)) {
+                Type::addType($name, $class);
+            }
+        }
+
         $platform = $this->getEm()->getConnection()->getDatabasePlatform();
 
         foreach ($doctrineConfig->customTypeMappings as $dbType => $doctrineType) {

--- a/src/Doctrine.php
+++ b/src/Doctrine.php
@@ -13,6 +13,7 @@ use Daycry\Doctrine\Config\Services;
 use Daycry\Doctrine\Debug\Toolbar\Collectors\DoctrineQueryMiddleware;
 use Daycry\Doctrine\Libraries\Memcached;
 use Daycry\Doctrine\Libraries\Redis;
+use Daycry\Doctrine\Logging\QueryLoggerMiddleware;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Tools\DsnParser;
@@ -25,6 +26,7 @@ use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Symfony\Component\Cache\Adapter\AdapterInterface as Psr6AdapterInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -189,14 +191,40 @@ class Doctrine
             $config->addFilter($name, $class);
         }
 
-        // Collector and middleware integration: capture every DBAL query for the toolbar.
-        // Only wired when query instrumentation is enabled (i.e. CI_DEBUG): in production
-        // the toolbar never renders, so wrapping every statement is pure dead weight.
-        $dbalConfig = new \Doctrine\DBAL\Configuration();
+        // Default repository class for entities that don't declare their own.
+        if ($doctrineConfig->defaultRepositoryClass !== null) {
+            $config->setDefaultRepositoryClassName($doctrineConfig->defaultRepositoryClass);
+        }
+
+        // DBAL middleware chain: user-defined middlewares (retry/logging/metrics)
+        // wrap the driver first (outermost); the toolbar capture middleware is
+        // applied last so it sees the final SQL closest to the driver. The toolbar
+        // middleware is only wired when query instrumentation is enabled (CI_DEBUG):
+        // in production the toolbar never renders, so wrapping every statement is
+        // pure dead weight.
+        $dbalConfig  = new \Doctrine\DBAL\Configuration();
+        $middlewares = [];
+
+        foreach ($doctrineConfig->dbalMiddlewares as $userMiddleware) {
+            $middlewares[] = is_string($userMiddleware) ? new $userMiddleware() : $userMiddleware;
+        }
+
+        // Production query logging (slow-query log) — independent of CI_DEBUG.
+        if ($doctrineConfig->queryLogging) {
+            $middlewares[] = new QueryLoggerMiddleware(
+                $this->logger(),
+                $doctrineConfig->slowQueryThreshold,
+                $doctrineConfig->queryLogLevel,
+            );
+        }
+
         if ($this->shouldInstrumentQueries()) {
-            $collector  = Services::doctrineCollector();
-            $middleware = new DoctrineQueryMiddleware($collector);
-            $dbalConfig->setMiddlewares([$middleware]);
+            $collector     = Services::doctrineCollector();
+            $middlewares[] = new DoctrineQueryMiddleware($collector);
+        }
+
+        if ($middlewares !== []) {
+            $dbalConfig->setMiddlewares($middlewares);
         }
 
         /** @var Database $dbConfig */
@@ -224,6 +252,15 @@ class Doctrine
     protected function shouldInstrumentQueries(): bool
     {
         return defined('CI_DEBUG') && CI_DEBUG;
+    }
+
+    /**
+     * PSR-3 logger used for production query logging. Defaults to CodeIgniter's
+     * logger service; override in a subclass to route logs elsewhere.
+     */
+    protected function logger(): LoggerInterface
+    {
+        return service('logger');
     }
 
     /**

--- a/src/Doctrine.php
+++ b/src/Doctrine.php
@@ -183,10 +183,14 @@ class Doctrine
         }
 
         // Collector and middleware integration: capture every DBAL query for the toolbar.
-        $collector  = Services::doctrineCollector();
+        // Only wired when query instrumentation is enabled (i.e. CI_DEBUG): in production
+        // the toolbar never renders, so wrapping every statement is pure dead weight.
         $dbalConfig = new \Doctrine\DBAL\Configuration();
-        $middleware = new DoctrineQueryMiddleware($collector);
-        $dbalConfig->setMiddlewares([$middleware]);
+        if ($this->shouldInstrumentQueries()) {
+            $collector  = Services::doctrineCollector();
+            $middleware = new DoctrineQueryMiddleware($collector);
+            $dbalConfig->setMiddlewares([$middleware]);
+        }
 
         /** @var Database $dbConfig */
         $dbConfig = config('Database');
@@ -203,6 +207,18 @@ class Doctrine
     }
 
     /**
+     * Whether DBAL queries should be instrumented for the Debug Toolbar.
+     *
+     * Defaults to CodeIgniter's debug flag: the toolbar only renders when
+     * CI_DEBUG is true, so production skips the per-query capture overhead.
+     * Override in a subclass to force instrumentation on or off.
+     */
+    protected function shouldInstrumentQueries(): bool
+    {
+        return defined('CI_DEBUG') && CI_DEBUG;
+    }
+
+    /**
      * Get the EntityManager. Throws if it has not been initialized.
      */
     public function getEm(): EntityManager
@@ -215,12 +231,29 @@ class Doctrine
     }
 
     /**
-     * Reopen the EntityManager with the current connection and configuration.
+     * Reopen the EntityManager, recovering from a stale or dropped database
+     * connection (e.g. "MySQL server has gone away" after an idle timeout in a
+     * long-running CLI worker or queue consumer).
+     *
+     * The existing DBAL connection is closed first so DBAL re-establishes the
+     * underlying socket lazily on the next query; a fresh EntityManager is then
+     * built over that connection with the same configuration, and custom type
+     * mappings are re-applied.
+     *
+     * Note: closing the connection discards an in-memory SQLite database. This
+     * method is intended for server-backed connections (MySQL/Postgres/…), which
+     * is the documented worker-recovery use case.
      */
     public function reOpen(): void
     {
-        $em       = $this->getEm();
-        $this->em = new EntityManager($em->getConnection(), $em->getConfiguration());
+        $em         = $this->getEm();
+        $connection = $em->getConnection();
+
+        if ($connection->isConnected()) {
+            $connection->close();
+        }
+
+        $this->em = new EntityManager($connection, $em->getConfiguration());
         $this->registerTypeMappings(config('Doctrine'));
     }
 

--- a/src/Helpers/getFromCacheOrQuery.php
+++ b/src/Helpers/getFromCacheOrQuery.php
@@ -16,7 +16,9 @@ use Daycry\Doctrine\Config\Services;
  * If no result cache is configured (`Config\Doctrine::$resultsCache = false`),
  * the query is always executed and nothing is cached.
  *
- * @param string      $cacheKey PSR-6 compatible cache key (no reserved characters: {}()/\@:)
+ * @param string      $cacheKey Cache key. PSR-6 reserved characters ({}()/\@:) are
+ *                              normalised automatically (sanitised + short hash of the
+ *                              original to avoid collisions), so any string is accepted.
  * @param int         $ttl      Lifetime in seconds; 0 means no expiration
  * @param callable    $queryFn  Closure that returns the value to cache
  * @param string|null $dbGroup  Optional CodeIgniter database group; null = default
@@ -32,7 +34,14 @@ function getFromCacheOrQuery(string $cacheKey, int $ttl, callable $queryFn, ?str
         return $queryFn();
     }
 
-    $item = $pool->getItem($cacheKey);
+    // Normalise PSR-6 reserved characters ({}()/\@:) so any caller key works; the
+    // appended hash of the original key keeps distinct keys from colliding.
+    $key = $cacheKey;
+    if (preg_match('~[{}()/\\\\@:]~', $key) === 1) {
+        $key = preg_replace('~[{}()/\\\\@:]~', '_', $key) . '_' . substr(sha1($cacheKey), 0, 12);
+    }
+
+    $item = $pool->getItem($key);
     if ($item->isHit()) {
         return $item->get();
     }

--- a/src/Logging/QueryLoggerMiddleware.php
+++ b/src/Logging/QueryLoggerMiddleware.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Daycry\Doctrine\Logging;
+
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\API\ExceptionConverter;
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\Middleware;
+use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\ServerVersionProvider;
+use Psr\Log\LoggerInterface;
+
+/**
+ * DBAL middleware that logs executed queries to a PSR-3 logger, optionally only
+ * those slower than a configured threshold. Unlike the Debug Toolbar collector
+ * this runs in any environment, giving production a slow-query log.
+ */
+class QueryLoggerMiddleware implements Middleware
+{
+    public function __construct(
+        protected LoggerInterface $logger,
+        protected float $slowThreshold = 0.0,
+        protected string $level = 'info',
+    ) {
+    }
+
+    /**
+     * Emit a log record when the query is at least as slow as the threshold.
+     *
+     * @param array<int|string, mixed> $params
+     */
+    public static function record(LoggerInterface $logger, string $level, float $threshold, string $sql, array $params, float $durationSeconds): void
+    {
+        if ($durationSeconds < $threshold) {
+            return;
+        }
+
+        $logger->log($level, 'Doctrine query', [
+            'sql'         => $sql,
+            'params'      => $params,
+            'duration_ms' => round($durationSeconds * 1000, 3),
+        ]);
+    }
+
+    public function wrap(Driver $driver): Driver
+    {
+        $logger    = $this->logger;
+        $threshold = $this->slowThreshold;
+        $level     = $this->level;
+
+        return new class ($driver, $logger, $threshold, $level) implements Driver {
+            public function __construct(
+                private readonly Driver $driver,
+                private readonly LoggerInterface $logger,
+                private readonly float $threshold,
+                private readonly string $level,
+            ) {
+            }
+
+            public function connect(array $params): Connection
+            {
+                $conn = $this->driver->connect($params);
+
+                return new class ($conn, $this->logger, $this->threshold, $this->level) implements Connection {
+                    public function __construct(
+                        private readonly Connection $conn,
+                        private readonly LoggerInterface $logger,
+                        private readonly float $threshold,
+                        private readonly string $level,
+                    ) {
+                    }
+
+                    public function prepare(string $sql): Statement
+                    {
+                        return new class ($this->conn->prepare($sql), $sql, $this->logger, $this->threshold, $this->level) implements Statement {
+                            /**
+                             * @var array<int|string, mixed>
+                             */
+                            private array $params = [];
+
+                            public function __construct(
+                                private readonly Statement $stmt,
+                                private readonly string $sql,
+                                private readonly LoggerInterface $logger,
+                                private readonly float $threshold,
+                                private readonly string $level,
+                            ) {
+                            }
+
+                            public function bindValue(int|string $param, mixed $value, ParameterType $type): void
+                            {
+                                $this->params[$param] = $value;
+                                $this->stmt->bindValue($param, $value, $type);
+                            }
+
+                            public function execute(): Result
+                            {
+                                $start  = microtime(true);
+                                $result = $this->stmt->execute();
+                                QueryLoggerMiddleware::record($this->logger, $this->level, $this->threshold, $this->sql, $this->params, microtime(true) - $start);
+
+                                return $result;
+                            }
+                        };
+                    }
+
+                    public function query(string $sql): Result
+                    {
+                        $start  = microtime(true);
+                        $result = $this->conn->query($sql);
+                        QueryLoggerMiddleware::record($this->logger, $this->level, $this->threshold, $sql, [], microtime(true) - $start);
+
+                        return $result;
+                    }
+
+                    public function exec(string $sql): int|string
+                    {
+                        $start  = microtime(true);
+                        $result = $this->conn->exec($sql);
+                        QueryLoggerMiddleware::record($this->logger, $this->level, $this->threshold, $sql, [], microtime(true) - $start);
+
+                        return $result;
+                    }
+
+                    public function beginTransaction(): void
+                    {
+                        $this->conn->beginTransaction();
+                    }
+
+                    public function commit(): void
+                    {
+                        $this->conn->commit();
+                    }
+
+                    public function rollBack(): void
+                    {
+                        $this->conn->rollBack();
+                    }
+
+                    public function lastInsertId(): int|string
+                    {
+                        return $this->conn->lastInsertId();
+                    }
+
+                    public function getNativeConnection()
+                    {
+                        return $this->conn->getNativeConnection();
+                    }
+
+                    public function quote(string $value): string
+                    {
+                        return $this->conn->quote($value);
+                    }
+
+                    public function getServerVersion(): string
+                    {
+                        return $this->conn->getServerVersion();
+                    }
+
+                    /**
+                     * @param array<int|string, mixed> $arguments
+                     */
+                    public function __call(string $name, array $arguments): mixed
+                    {
+                        /** @var mixed */
+                        return $this->conn->{$name}(...$arguments);
+                    }
+                };
+            }
+
+            public function getDatabasePlatform(ServerVersionProvider $versionProvider): AbstractPlatform
+            {
+                return $this->driver->getDatabasePlatform($versionProvider);
+            }
+
+            public function getExceptionConverter(): ExceptionConverter
+            {
+                return $this->driver->getExceptionConverter();
+            }
+        };
+    }
+}

--- a/src/cli-config.php
+++ b/src/cli-config.php
@@ -8,13 +8,15 @@
  * @see       https://github.com/daycry/doctrine
  */
 
-require_once 'vendor/autoload.php';
+require_once __DIR__ . '/vendor/autoload.php';
 
 use Config\Paths;
 use Daycry\Doctrine\Boot;
+use Daycry\Doctrine\Config\Doctrine as DoctrineConfig;
 use Daycry\Doctrine\Doctrine;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Console\ConsoleRunner;
-use Doctrine\ORM\Tools\Console\EntityManagerProvider\SingleManagerProvider;
+use Doctrine\ORM\Tools\Console\EntityManagerProvider;
 
 // Path to the front controller (this file)
 define('FCPATH', __DIR__ . DIRECTORY_SEPARATOR);
@@ -55,20 +57,34 @@ require $paths->systemDirectory . '/Boot.php';
 // Load environment settings from .env files into $_SERVER and $_ENV
 Boot::bootDoctrine($paths);
 
-$doctrine = new Doctrine(config('Doctrine'));
+// Lazily build one EntityManager per CodeIgniter database group, so the Doctrine
+// ORM CLI can target any group with `--em=<group>` (the default group is used
+// when the option is omitted). This avoids accidentally running schema/DDL
+// commands against the wrong database in multi-group applications.
+$provider = new class (config('Doctrine')) implements EntityManagerProvider {
+    /**
+     * @var array<string, EntityManagerInterface>
+     */
+    private array $managers = [];
 
-if ($doctrine->em === null) {
-    echo 'EntityManager could not be initialized.' . PHP_EOL;
+    public function __construct(private readonly DoctrineConfig $config)
+    {
+    }
 
-    exit(1);
-}
+    public function getDefaultManager(): EntityManagerInterface
+    {
+        return $this->getManager(config('Database')->defaultGroup);
+    }
+
+    public function getManager(string $name): EntityManagerInterface
+    {
+        return $this->managers[$name] ??= (new Doctrine($this->config, null, $name))->getEm();
+    }
+};
 
 $commands = [
     // If you want to add your own custom console commands,
     // you can do so here.
 ];
 
-ConsoleRunner::run(
-    new SingleManagerProvider($doctrine->em),
-    $commands,
-);
+ConsoleRunner::run($provider, $commands);

--- a/tests/Commands/DoctrineCacheClearTest.php
+++ b/tests/Commands/DoctrineCacheClearTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Commands;
 
 use Daycry\Doctrine\Config\Services;
+use Psr\Cache\CacheItemPoolInterface;
 use Tests\Support\TestCase;
 
 /**
@@ -20,7 +21,7 @@ final class DoctrineCacheClearTest extends TestCase
 
         Services::resetDoctrine('tests');
         $pool = Services::doctrine(true, 'tests')->getEm()->getConfiguration()->getResultCache();
-        $this->assertNotNull($pool);
+        $this->assertInstanceOf(CacheItemPoolInterface::class, $pool);
 
         $item = $pool->getItem('audit_cache_probe');
         $item->set('value');

--- a/tests/Commands/DoctrineCacheClearTest.php
+++ b/tests/Commands/DoctrineCacheClearTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Commands;
+
+use Daycry\Doctrine\Config\Services;
+use Tests\Support\TestCase;
+
+/**
+ * @internal
+ */
+final class DoctrineCacheClearTest extends TestCase
+{
+    public function testCacheClearEmptiesTheResultCachePool(): void
+    {
+        $db                    = config('Database');
+        $db->tests['DBDriver'] = 'SQLite3';
+        $db->tests['database'] = ':memory:';
+
+        Services::resetDoctrine('tests');
+        $pool = Services::doctrine(true, 'tests')->getEm()->getConfiguration()->getResultCache();
+        $this->assertNotNull($pool);
+
+        $item = $pool->getItem('audit_cache_probe');
+        $item->set('value');
+        $pool->save($item);
+        $this->assertTrue($pool->getItem('audit_cache_probe')->isHit(), 'pre-condition: item is cached');
+
+        command('doctrine:cache:clear --group tests');
+
+        $this->assertFalse($pool->getItem('audit_cache_probe')->isHit(), 'cache:clear must empty the pool');
+
+        Services::resetDoctrine('tests');
+    }
+}

--- a/tests/Commands/DoctrineConsoleCommandsTest.php
+++ b/tests/Commands/DoctrineConsoleCommandsTest.php
@@ -6,7 +6,9 @@ namespace Tests\Commands;
 
 use Daycry\Doctrine\Commands\DoctrineInfo;
 use Daycry\Doctrine\Commands\DoctrineSchemaUpdate;
+use Daycry\Doctrine\Commands\DoctrineValidate;
 use Daycry\Doctrine\Config\Services;
+use Doctrine\ORM\Tools\SchemaTool;
 use Tests\Support\TestCase;
 
 /**
@@ -47,6 +49,26 @@ final class DoctrineConsoleCommandsTest extends TestCase
         $command = new DoctrineSchemaUpdate(service('logger'), service('commands'));
 
         // No --force: defaults to a non-destructive --dump-sql dry run.
+        $this->assertSame(0, $command->run(['group' => 'tests']));
+    }
+
+    public function testSchemaUpdateWrapperWithForceAppliesDdl(): void
+    {
+        $command = new DoctrineSchemaUpdate(service('logger'), service('commands'));
+
+        $this->assertSame(0, $command->run(['group' => 'tests', 'force' => null]));
+    }
+
+    public function testValidateWrapperExitsZeroOnSyncedSchema(): void
+    {
+        // Create the full schema on the shared 'tests' instance the command reuses,
+        // so orm:validate-schema finds the database in sync and exits 0.
+        $em   = Services::doctrine(true, 'tests')->getEm();
+        $tool = new SchemaTool($em);
+        $tool->createSchema($em->getMetadataFactory()->getAllMetadata());
+
+        $command = new DoctrineValidate(service('logger'), service('commands'));
+
         $this->assertSame(0, $command->run(['group' => 'tests']));
     }
 }

--- a/tests/Commands/DoctrineConsoleCommandsTest.php
+++ b/tests/Commands/DoctrineConsoleCommandsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Commands;
+
+use Daycry\Doctrine\Commands\DoctrineInfo;
+use Daycry\Doctrine\Commands\DoctrineSchemaUpdate;
+use Daycry\Doctrine\Config\Services;
+use Tests\Support\TestCase;
+
+/**
+ * Smoke tests for the ORM-console Spark wrappers: verify they resolve the
+ * EntityManager for the requested group, bridge to the ORM console command and
+ * exit successfully.
+ *
+ * @internal
+ */
+final class DoctrineConsoleCommandsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $db                    = config('Database');
+        $db->tests['DBDriver'] = 'SQLite3';
+        $db->tests['database'] = ':memory:';
+
+        Services::resetDoctrine('tests');
+    }
+
+    protected function tearDown(): void
+    {
+        Services::resetDoctrine('tests');
+        parent::tearDown();
+    }
+
+    public function testInfoWrapperListsEntitiesAndExitsZero(): void
+    {
+        $command = new DoctrineInfo(service('logger'), service('commands'));
+
+        $this->assertSame(0, $command->run(['group' => 'tests']));
+    }
+
+    public function testSchemaUpdateWrapperDumpsSqlAndExitsZero(): void
+    {
+        $command = new DoctrineSchemaUpdate(service('logger'), service('commands'));
+
+        // No --force: defaults to a non-destructive --dump-sql dry run.
+        $this->assertSame(0, $command->run(['group' => 'tests']));
+    }
+}

--- a/tests/DataTableTest.php
+++ b/tests/DataTableTest.php
@@ -130,6 +130,95 @@ final class DataTableTest extends TestCase
         $this->assertCount(1, $response['data']);
     }
 
+    public function testOrderingWithOutOfRangeColumnIndexIsIgnored()
+    {
+        $this->getMysqlDSNConfig();
+
+        $doctrine = new Doctrine($this->config);
+
+        $datatables = (new Builder())
+            ->withColumnAliases(['id' => 't.id', 'name' => 't.name'])
+            ->setUseOutputWalkers(false)
+            ->withQueryBuilder(
+                $doctrine->em->createQueryBuilder()
+                    ->select('t.id, t.name')
+                    ->from(TestAttribute::class, 't'),
+            )
+            ->withRequestParams([
+                'draw'    => 1,
+                'start'   => 0,
+                'length'  => 10,
+                'columns' => [
+                    ['data' => 'id', 'name' => 'id', 'searchable' => true, 'orderable' => true, 'search' => ['value' => '', 'regex' => false]],
+                    ['data' => 'name', 'name' => 'name', 'searchable' => true, 'orderable' => true, 'search' => ['value' => '', 'regex' => false]],
+                ],
+                // Attacker/garbage column index out of range — must be ignored, not warn.
+                'order' => [['column' => 5, 'dir' => 'asc']],
+            ]);
+
+        $response = $datatables->getResponse();
+        $this->assertCount(2, $response['data']);
+    }
+
+    public function testOrOperatorHonorsCaseInsensitive()
+    {
+        $this->getMysqlDSNConfig();
+
+        $doctrine = new Doctrine($this->config);
+
+        $query = (new Builder())
+            ->withColumnAliases(['name' => 't.name'])
+            ->withCaseInsensitive(true)
+            ->withColumnField('name')
+            ->withQueryBuilder(
+                $doctrine->em->createQueryBuilder()
+                    ->select('t')
+                    ->from(TestAttribute::class, 't'),
+            )
+            ->withRequestParams([
+                'draw'    => 1,
+                'columns' => [
+                    ['name' => 'name', 'searchable' => true, 'search' => ['value' => '[OR]name1,name2', 'regex' => false]],
+                ],
+            ])
+            ->getFilteredQuery();
+
+        // Case-insensitive [OR] must wrap BOTH the column and each placeholder in lower(),
+        // exactly like the global search and the default LIKE branch already do.
+        $dql = $query->getDQL();
+        $this->assertStringContainsString('lower(t.name) LIKE lower(:filter_0_0)', $dql);
+        $this->assertStringContainsString('lower(:filter_0_1)', $dql);
+    }
+
+    public function testMaxPageLengthCapsUnboundedAllRequest()
+    {
+        $this->getMysqlDSNConfig();
+
+        $doctrine = new Doctrine($this->config);
+
+        $datatables = (new Builder())
+            ->withColumnAliases(['id' => 't.id', 'name' => 't.name'])
+            ->setUseOutputWalkers(false)
+            ->withMaxPageLength(1)
+            ->withQueryBuilder(
+                $doctrine->em->createQueryBuilder()
+                    ->select('t.id, t.name')
+                    ->from(TestAttribute::class, 't'),
+            )
+            ->withRequestParams([
+                'draw'    => 1,
+                'start'   => 0,
+                'length'  => -1, // DataTables "All" — must not bypass the cap
+                'columns' => [
+                    ['data' => 'id', 'name' => 'id', 'searchable' => true, 'orderable' => true, 'search' => ['value' => '', 'regex' => false]],
+                    ['data' => 'name', 'name' => 'name', 'searchable' => true, 'orderable' => true, 'search' => ['value' => '', 'regex' => false]],
+                ],
+            ]);
+
+        // Two rows are seeded; the cap must limit the unbounded "All" request to 1.
+        $this->assertCount(1, $datatables->getData());
+    }
+
     public function testDataTableSearchColumnWithPercent()
     {
         $this->getMysqlDSNConfig();

--- a/tests/DataTableTest.php
+++ b/tests/DataTableTest.php
@@ -6,6 +6,7 @@ namespace Tests;
 
 use CodeIgniter\Test\DatabaseTestTrait;
 use CodeIgniter\Test\FeatureTestTrait;
+use Daycry\Doctrine\Config\Services;
 use Daycry\Doctrine\DataTables\Builder;
 use Daycry\Doctrine\Doctrine;
 use Tests\Support\Database\Seeds\TestSeeder;
@@ -128,6 +129,97 @@ final class DataTableTest extends TestCase
 
         $this->assertArrayHasKey('data', $response);
         $this->assertCount(1, $response['data']);
+    }
+
+    public function testWithRecordsTotalBypassesTheCountQuery()
+    {
+        $this->getMysqlDSNConfig();
+
+        $doctrine  = new Doctrine($this->config);
+        $collector = Services::doctrineCollector();
+
+        $builder = (new Builder())
+            ->withColumnAliases(['id' => 't.id', 'name' => 't.name'])
+            ->withRecordsTotal(999)
+            ->withQueryBuilder(
+                $doctrine->em->createQueryBuilder()->select('t')->from(TestAttribute::class, 't'),
+            )
+            ->withRequestParams([
+                'draw'    => 1,
+                'start'   => 0,
+                'length'  => 10,
+                'columns' => [
+                    ['data' => 'id', 'name' => 'id', 'searchable' => true, 'orderable' => true, 'search' => ['value' => '', 'regex' => false]],
+                    ['data' => 'name', 'name' => 'name', 'searchable' => true, 'orderable' => true, 'search' => ['value' => '', 'regex' => false]],
+                ],
+            ]);
+
+        $collector->reset();
+        $total   = $builder->getRecordsTotal();
+        $queries = count($collector->getQueries());
+
+        $this->assertSame(999, $total);
+        $this->assertSame(0, $queries, 'an injected total must not issue a count query');
+    }
+
+    public function testWithRecordsTotalAcceptsAClosure()
+    {
+        $this->getMysqlDSNConfig();
+
+        $doctrine = new Doctrine($this->config);
+
+        $builder = (new Builder())
+            ->withColumnAliases(['id' => 't.id', 'name' => 't.name'])
+            ->withRecordsTotal(static fn (): int => 1234)
+            ->withQueryBuilder(
+                $doctrine->em->createQueryBuilder()->select('t')->from(TestAttribute::class, 't'),
+            )
+            ->withRequestParams([
+                'draw'    => 1,
+                'start'   => 0,
+                'length'  => 10,
+                'columns' => [
+                    ['data' => 'id', 'name' => 'id', 'searchable' => true, 'orderable' => true, 'search' => ['value' => '', 'regex' => false]],
+                    ['data' => 'name', 'name' => 'name', 'searchable' => true, 'orderable' => true, 'search' => ['value' => '', 'regex' => false]],
+                ],
+            ]);
+
+        $this->assertSame(1234, $builder->getResponse()['recordsTotal']);
+    }
+
+    public function testFetchJoinCollectionOptOutReducesDataQueries()
+    {
+        $this->getMysqlDSNConfig();
+
+        $doctrine  = new Doctrine($this->config);
+        $collector = Services::doctrineCollector();
+
+        $build = static fn (): Builder => (new Builder())
+            ->withColumnAliases(['id' => 't.id', 'name' => 't.name'])
+            ->withQueryBuilder(
+                $doctrine->em->createQueryBuilder()->select('t')->from(TestAttribute::class, 't'),
+            )
+            ->withRequestParams([
+                'draw'    => 1,
+                'start'   => 0,
+                'length'  => 10,
+                'columns' => [
+                    ['data' => 'id', 'name' => 'id', 'searchable' => true, 'orderable' => true, 'search' => ['value' => '', 'regex' => false]],
+                    ['data' => 'name', 'name' => 'name', 'searchable' => true, 'orderable' => true, 'search' => ['value' => '', 'regex' => false]],
+                ],
+            ]);
+
+        // Default fetchJoinCollection=true issues an id sub-query + WHERE-IN fetch.
+        $collector->reset();
+        $build()->getData();
+        $withJoin = count($collector->getQueries());
+
+        // Opting out collapses the page fetch into a single query.
+        $collector->reset();
+        $build()->withFetchJoinCollection(false)->getData();
+        $withoutJoin = count($collector->getQueries());
+
+        $this->assertLessThan($withJoin, $withoutJoin);
     }
 
     public function testOrderingWithOutOfRangeColumnIndexIsIgnored()

--- a/tests/DoctrineQueryLoggerCoverageTest.php
+++ b/tests/DoctrineQueryLoggerCoverageTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use Daycry\Doctrine\Config\Doctrine as DoctrineConfig;
+use Daycry\Doctrine\Doctrine;
+use Doctrine\ORM\Tools\SchemaTool;
+use Psr\Log\LoggerInterface;
+use Tests\Support\Log\SpyLogger;
+use Tests\Support\Models\Entities\TestAttribute;
+use Tests\Support\TestCase;
+use Throwable;
+
+/**
+ * Exercises QueryLoggerMiddleware's wrapped Connection methods (query, exec,
+ * prepare/execute, transactions, quote, native connection, server version,
+ * exception converter) through real SQLite operations with query logging on.
+ *
+ * @internal
+ */
+final class DoctrineQueryLoggerCoverageTest extends TestCase
+{
+    private Doctrine $doctrine;
+    private SpyLogger $spy;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $db                    = config('Database');
+        $db->tests['DBDriver'] = 'SQLite3';
+        $db->tests['database'] = ':memory:';
+
+        $this->config->entities           = [SUPPORTPATH . 'Models/Entities'];
+        $this->config->queryLogging       = true;
+        $this->config->slowQueryThreshold = 0.0;
+
+        $this->spy      = new SpyLogger();
+        $spy            = $this->spy;
+        $this->doctrine = new class ($this->config, $spy) extends Doctrine {
+            public function __construct(DoctrineConfig $config, private readonly LoggerInterface $spyLogger)
+            {
+                parent::__construct($config, null, 'tests');
+            }
+
+            protected function logger(): LoggerInterface
+            {
+                return $this->spyLogger;
+            }
+        };
+    }
+
+    private function createSchema(): SchemaTool
+    {
+        $tool     = new SchemaTool($this->doctrine->em);
+        $metadata = $this->doctrine->em->getClassMetadata(TestAttribute::class);
+        $tool->createSchema([$metadata]);
+
+        return $tool;
+    }
+
+    private function dropSchema(SchemaTool $tool): void
+    {
+        try {
+            $metadata = $this->doctrine->em->getClassMetadata(TestAttribute::class);
+            $tool->dropSchema([$metadata]);
+        } catch (Throwable) {
+            // ignore cleanup errors
+        }
+    }
+
+    public function testLoggerCoversQueryExecPrepareAndTransactions(): void
+    {
+        $tool = $this->createSchema();
+        $conn = $this->doctrine->em->getConnection();
+
+        // query() — parameterless SELECT
+        $this->assertSame(1, $conn->executeQuery('SELECT 1')->fetchOne());
+
+        // prepare()/execute() + transaction commit
+        $conn->beginTransaction();
+        $conn->executeStatement('INSERT INTO test (name, created_at) VALUES (?, ?)', ['log_tx', '2026-01-01 00:00:00']);
+        $conn->commit();
+
+        // transaction rollback
+        $conn->beginTransaction();
+        $conn->executeStatement('INSERT INTO test (name, created_at) VALUES (?, ?)', ['log_rb', '2026-01-01 00:00:00']);
+        $conn->rollBack();
+
+        // exec() — parameterless statement
+        $conn->executeStatement('DELETE FROM test WHERE name = \'never\'');
+
+        $id      = $conn->lastInsertId();
+        $native  = $conn->getNativeConnection();
+        $quoted  = $conn->quote("O'Reilly");
+        $version = $conn->getServerVersion();
+
+        $this->assertNotEmpty($this->spy->records, 'query logging should have recorded queries');
+        $this->assertNotEmpty((string) $id);
+        $this->assertNotNull($native);
+        $this->assertIsString($quoted);
+        $this->assertNotEmpty($version);
+
+        $this->dropSchema($tool);
+    }
+
+    public function testLoggerGetExceptionConverterOnInvalidSql(): void
+    {
+        $conn = $this->doctrine->em->getConnection();
+
+        try {
+            $conn->executeQuery('INVALID SQL STATEMENT');
+            $this->fail('Expected an exception for invalid SQL');
+        } catch (Throwable $e) {
+            $this->assertNotEmpty($e->getMessage());
+        }
+    }
+
+    public function testLoggerSkipsQueriesBelowThreshold(): void
+    {
+        // A very high threshold means nothing is logged.
+        $this->config->slowQueryThreshold = 9999.0;
+
+        $spy      = new SpyLogger();
+        $doctrine = new class ($this->config, $spy) extends Doctrine {
+            public function __construct(DoctrineConfig $config, private readonly LoggerInterface $spyLogger)
+            {
+                parent::__construct($config, null, 'tests');
+            }
+
+            protected function logger(): LoggerInterface
+            {
+                return $this->spyLogger;
+            }
+        };
+
+        $doctrine->em->getConnection()->executeQuery('SELECT 1')->fetchOne();
+
+        $this->assertSame([], $spy->records, 'no query is slow enough to be logged');
+    }
+}

--- a/tests/DoctrineTest.php
+++ b/tests/DoctrineTest.php
@@ -10,6 +10,7 @@ use Config\Services;
 use Daycry\Doctrine\Doctrine;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManager;
+use Psr\Cache\CacheItemPoolInterface;
 use Psr\Log\LoggerInterface;
 use Tests\Support\Database\Seeds\TestSeeder;
 use Tests\Support\Filters\SoftDeleteFilter;
@@ -270,6 +271,55 @@ final class DoctrineTest extends TestCase
         // DriverManager::getConnection() wraps the driver through every middleware
         // eagerly, so the user middleware must have been invoked.
         $this->assertTrue(RecordingMiddleware::$wrapped);
+    }
+
+    public function testResultCacheIsIsolatedPerDbGroup()
+    {
+        $cache          = config('Cache');
+        $cache->handler = 'file';
+
+        $db                      = config('Database');
+        $db->tests['DBDriver']   = 'SQLite3';
+        $db->tests['database']   = ':memory:';
+        $db->default['DBDriver'] = 'SQLite3';
+        $db->default['database'] = ':memory:';
+
+        \Daycry\Doctrine\Config\Services::resetDoctrine('default');
+        \Daycry\Doctrine\Config\Services::resetDoctrine('tests');
+
+        // 'default' is the default group (no suffix); 'tests' is a non-default
+        // group (suffixed). Their cache pools must not collide.
+        $poolDefault = (new Doctrine($this->config, $cache, 'default'))->em->getConfiguration()->getResultCache();
+        $poolTests   = (new Doctrine($this->config, $cache, 'tests'))->em->getConfiguration()->getResultCache();
+
+        $this->assertInstanceOf(CacheItemPoolInterface::class, $poolDefault);
+        $this->assertInstanceOf(CacheItemPoolInterface::class, $poolTests);
+        $poolDefault->clear();
+        $poolTests->clear();
+
+        $item = $poolTests->getItem('group_isolation_probe');
+        $item->set('from-tests');
+        $poolTests->save($item);
+
+        $this->assertFalse(
+            $poolDefault->getItem('group_isolation_probe')->isHit(),
+            'cache pools for different DB groups must not collide',
+        );
+
+        $poolTests->clear();
+        \Daycry\Doctrine\Config\Services::resetDoctrine('default');
+        \Daycry\Doctrine\Config\Services::resetDoctrine('tests');
+    }
+
+    public function testConvertDbConfigPreservesSqliteDsnPathCase()
+    {
+        $doctrine = new Doctrine($this->config);
+
+        // Only the scheme should be lower-cased; a case-sensitive file path must
+        // survive intact (lowercasing it would open/create the wrong DB file).
+        $options = $doctrine->convertDbConfig((object) ['DSN' => 'SQLite3:/Var/Data/MyApp.sqlite']);
+
+        $this->assertStringContainsString('MyApp', (string) json_encode($options), 'SQLite DSN path case must be preserved');
     }
 
     public function testDoctrineWithCustomDbGroup()

--- a/tests/DoctrineTest.php
+++ b/tests/DoctrineTest.php
@@ -124,6 +124,56 @@ final class DoctrineTest extends TestCase
         $this->assertInstanceOf(EntityManager::class, $doctrine->em);
     }
 
+    public function testReOpenClosesAndReconnectsConnection()
+    {
+        $doctrine = new Doctrine($this->config);
+
+        // Establish a live connection.
+        $doctrine->em->getConnection()->executeQuery('SELECT 1');
+        $this->assertTrue($doctrine->em->getConnection()->isConnected());
+
+        $doctrine->reOpen();
+
+        // reOpen() must drop the underlying connection so a stale socket is
+        // re-established lazily on the next query (the documented worker use case).
+        $this->assertFalse($doctrine->em->getConnection()->isConnected());
+
+        // The connection still works and reconnects transparently on next use.
+        $value = $doctrine->em->getConnection()->executeQuery('SELECT 1')->fetchOne();
+        $this->assertSame(1, (int) $value);
+        $this->assertTrue($doctrine->em->getConnection()->isConnected());
+    }
+
+    public function testQueryInstrumentationCanBeDisabled()
+    {
+        $collector = \Daycry\Doctrine\Config\Services::doctrineCollector();
+        $collector->reset();
+
+        // Simulate production (CI_DEBUG off): the toolbar middleware must not be wired.
+        $doctrine = new class ($this->config) extends Doctrine {
+            protected function shouldInstrumentQueries(): bool
+            {
+                return false;
+            }
+        };
+
+        $doctrine->em->getConnection()->executeQuery('SELECT 1');
+
+        $this->assertCount(0, $collector->getQueries());
+    }
+
+    public function testQueryInstrumentationEnabledByDefaultCapturesQueries()
+    {
+        $collector = \Daycry\Doctrine\Config\Services::doctrineCollector();
+        $collector->reset();
+
+        // CI_DEBUG is true under the testing environment, so capture stays on.
+        $doctrine = new Doctrine($this->config);
+        $doctrine->em->getConnection()->executeQuery('SELECT 1');
+
+        $this->assertGreaterThan(0, count($collector->getQueries()));
+    }
+
     public function testDoctrineWithCustomDbGroup()
     {
         $dbConfig = config('Database');

--- a/tests/DoctrineTest.php
+++ b/tests/DoctrineTest.php
@@ -10,10 +10,14 @@ use Config\Services;
 use Daycry\Doctrine\Doctrine;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManager;
+use Psr\Log\LoggerInterface;
 use Tests\Support\Database\Seeds\TestSeeder;
 use Tests\Support\Filters\SoftDeleteFilter;
 use Tests\Support\Listeners\RecordingListener;
 use Tests\Support\Listeners\RecordingSubscriber;
+use Tests\Support\Log\SpyLogger;
+use Tests\Support\Middlewares\RecordingMiddleware;
+use Tests\Support\Repositories\CustomRepository;
 use Tests\Support\TestCase;
 use Tests\Support\Types\CustomStringType;
 
@@ -212,6 +216,60 @@ final class DoctrineTest extends TestCase
 
         $this->assertTrue($evm->hasListeners('prePersist'), 'configured listener should be registered');
         $this->assertTrue($evm->hasListeners('postLoad'), 'subscriber event should be registered');
+    }
+
+    public function testQueryLoggingLogsQueriesToPsr3Logger()
+    {
+        $spy = new SpyLogger();
+
+        $db                    = config('Database');
+        $db->tests['DBDriver'] = 'SQLite3';
+        $db->tests['database'] = ':memory:';
+
+        $this->config->queryLogging       = true;
+        $this->config->slowQueryThreshold = 0.0; // log every query
+
+        $doctrine = new class ($this->config, $spy) extends Doctrine {
+            public function __construct(\Daycry\Doctrine\Config\Doctrine $config, private readonly LoggerInterface $spy)
+            {
+                parent::__construct($config, null, 'tests');
+            }
+
+            protected function logger(): LoggerInterface
+            {
+                return $this->spy;
+            }
+        };
+
+        $doctrine->em->getConnection()->executeQuery('SELECT 1');
+
+        $this->assertNotEmpty($spy->records, 'query logging should emit at least one log record');
+        $sqls = array_column(array_column($spy->records, 'context'), 'sql');
+        $this->assertNotEmpty(array_filter($sqls, static fn ($sql): bool => str_contains((string) $sql, 'SELECT 1')));
+    }
+
+    public function testDefaultRepositoryClassIsConfigured()
+    {
+        $this->config->defaultRepositoryClass = CustomRepository::class;
+
+        $doctrine = new Doctrine($this->config);
+
+        $this->assertSame(
+            CustomRepository::class,
+            $doctrine->em->getConfiguration()->getDefaultRepositoryClassName(),
+        );
+    }
+
+    public function testUserDbalMiddlewaresAreComposed()
+    {
+        RecordingMiddleware::$wrapped  = false;
+        $this->config->dbalMiddlewares = [RecordingMiddleware::class];
+
+        new Doctrine($this->config);
+
+        // DriverManager::getConnection() wraps the driver through every middleware
+        // eagerly, so the user middleware must have been invoked.
+        $this->assertTrue(RecordingMiddleware::$wrapped);
     }
 
     public function testDoctrineWithCustomDbGroup()

--- a/tests/DoctrineTest.php
+++ b/tests/DoctrineTest.php
@@ -8,9 +8,14 @@ use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Cache;
 use Config\Services;
 use Daycry\Doctrine\Doctrine;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManager;
 use Tests\Support\Database\Seeds\TestSeeder;
+use Tests\Support\Filters\SoftDeleteFilter;
+use Tests\Support\Listeners\RecordingListener;
+use Tests\Support\Listeners\RecordingSubscriber;
 use Tests\Support\TestCase;
+use Tests\Support\Types\CustomStringType;
 
 /**
  * @internal
@@ -172,6 +177,41 @@ final class DoctrineTest extends TestCase
         $doctrine->em->getConnection()->executeQuery('SELECT 1');
 
         $this->assertGreaterThan(0, count($collector->getQueries()));
+    }
+
+    public function testCustomTypesAreRegistered()
+    {
+        $this->config->customTypes = [CustomStringType::NAME => CustomStringType::class];
+
+        new Doctrine($this->config);
+
+        $this->assertTrue(Type::hasType(CustomStringType::NAME));
+    }
+
+    public function testSqlFiltersAreRegisteredAndEnabled()
+    {
+        $this->config->sqlFilters     = ['soft_delete' => SoftDeleteFilter::class];
+        $this->config->enabledFilters = ['soft_delete'];
+
+        $doctrine = new Doctrine($this->config);
+
+        $this->assertTrue($doctrine->em->getFilters()->isEnabled('soft_delete'));
+
+        // Auto-enabled filters survive a reOpen() (re-enabled on the rebuilt EM).
+        $doctrine->reOpen();
+        $this->assertTrue($doctrine->em->getFilters()->isEnabled('soft_delete'));
+    }
+
+    public function testEventListenersAndSubscribersAreRegistered()
+    {
+        $this->config->eventListeners   = ['prePersist' => [RecordingListener::class]];
+        $this->config->eventSubscribers = [RecordingSubscriber::class];
+
+        $doctrine = new Doctrine($this->config);
+        $evm      = $doctrine->em->getEventManager();
+
+        $this->assertTrue($evm->hasListeners('prePersist'), 'configured listener should be registered');
+        $this->assertTrue($evm->hasListeners('postLoad'), 'subscriber event should be registered');
     }
 
     public function testDoctrineWithCustomDbGroup()

--- a/tests/GetFromCacheOrQueryTest.php
+++ b/tests/GetFromCacheOrQueryTest.php
@@ -95,6 +95,26 @@ final class GetFromCacheOrQueryTest extends TestCase
         $this->assertSame(2, $calls);
     }
 
+    public function testHandlesPsr6ReservedCharacterKeys(): void
+    {
+        // PSR-6 reserves {}()/\@: — a caller key containing them must not throw
+        // and must still cache (and dedupe) correctly.
+        $key     = 'user:42/profile{a}';
+        $calls   = 0;
+        $queryFn = static function () use (&$calls) {
+            $calls++;
+
+            return 'cached-value';
+        };
+
+        $first  = getFromCacheOrQuery($key, 60, $queryFn);
+        $second = getFromCacheOrQuery($key, 60, $queryFn);
+
+        $this->assertSame('cached-value', $first);
+        $this->assertSame('cached-value', $second);
+        $this->assertSame(1, $calls, 'reserved-char key must be normalized and cached, not re-run or throw');
+    }
+
     public function testTtlZeroPersistsWithoutExpiration(): void
     {
         $key     = 'test_ttl0_' . uniqid();

--- a/tests/_support/Filters/SoftDeleteFilter.php
+++ b/tests/_support/Filters/SoftDeleteFilter.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support\Filters;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Query\Filter\SQLFilter;
+
+/**
+ * Minimal SQL filter fixture used to exercise Config\Doctrine::$sqlFilters /
+ * $enabledFilters wiring. Returns no constraint so it is safe on any entity.
+ */
+final class SoftDeleteFilter extends SQLFilter
+{
+    public function addFilterConstraint(ClassMetadata $targetEntity, string $targetTableAlias): string
+    {
+        return '';
+    }
+}

--- a/tests/_support/Listeners/RecordingListener.php
+++ b/tests/_support/Listeners/RecordingListener.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support\Listeners;
+
+/**
+ * Plain event listener fixture (method named after the Doctrine event).
+ */
+final class RecordingListener
+{
+    public function prePersist(): void
+    {
+    }
+}

--- a/tests/_support/Listeners/RecordingListener.php
+++ b/tests/_support/Listeners/RecordingListener.php
@@ -9,7 +9,4 @@ namespace Tests\Support\Listeners;
  */
 final class RecordingListener
 {
-    public function prePersist(): void
-    {
-    }
 }

--- a/tests/_support/Listeners/RecordingSubscriber.php
+++ b/tests/_support/Listeners/RecordingSubscriber.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support\Listeners;
+
+use Doctrine\Common\EventSubscriber;
+
+/**
+ * Event subscriber fixture that subscribes to postLoad.
+ */
+final class RecordingSubscriber implements EventSubscriber
+{
+    /**
+     * @return list<string>
+     */
+    public function getSubscribedEvents(): array
+    {
+        return ['postLoad'];
+    }
+
+    public function postLoad(): void
+    {
+    }
+}

--- a/tests/_support/Listeners/RecordingSubscriber.php
+++ b/tests/_support/Listeners/RecordingSubscriber.php
@@ -18,8 +18,4 @@ final class RecordingSubscriber implements EventSubscriber
     {
         return ['postLoad'];
     }
-
-    public function postLoad(): void
-    {
-    }
 }

--- a/tests/_support/Log/SpyLogger.php
+++ b/tests/_support/Log/SpyLogger.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support\Log;
+
+use Psr\Log\AbstractLogger;
+use Stringable;
+
+/**
+ * PSR-3 logger spy that records every log call, used to verify query logging.
+ */
+final class SpyLogger extends AbstractLogger
+{
+    /**
+     * @var list<array{level: mixed, message: string, context: array<array-key, mixed>}>
+     */
+    public array $records = [];
+
+    public function log($level, string|Stringable $message, array $context = []): void
+    {
+        $this->records[] = ['level' => $level, 'message' => (string) $message, 'context' => $context];
+    }
+}

--- a/tests/_support/Middlewares/RecordingMiddleware.php
+++ b/tests/_support/Middlewares/RecordingMiddleware.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support\Middlewares;
+
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\Middleware;
+
+/**
+ * DBAL middleware fixture that records when its wrap() is invoked, used to
+ * verify Config\Doctrine::$dbalMiddlewares composition.
+ */
+final class RecordingMiddleware implements Middleware
+{
+    public static bool $wrapped = false;
+
+    public function wrap(Driver $driver): Driver
+    {
+        self::$wrapped = true;
+
+        return $driver;
+    }
+}

--- a/tests/_support/Repositories/CustomRepository.php
+++ b/tests/_support/Repositories/CustomRepository.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support\Repositories;
+
+use Doctrine\ORM\EntityRepository;
+
+/**
+ * Custom default repository fixture used to verify
+ * Config\Doctrine::$defaultRepositoryClass wiring.
+ *
+ * @template T of object
+ *
+ * @extends EntityRepository<T>
+ */
+class CustomRepository extends EntityRepository
+{
+}

--- a/tests/_support/Types/CustomStringType.php
+++ b/tests/_support/Types/CustomStringType.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+
+/**
+ * Minimal custom DBAL Type used to exercise Config\Doctrine::$customTypes
+ * registration. DBAL 4 removed Type::getName(), so only getSQLDeclaration()
+ * is required.
+ */
+final class CustomStringType extends Type
+{
+    public const NAME = 'custom_string';
+
+    /**
+     * @param array<string, mixed> $column
+     */
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        return $platform->getStringTypeDeclarationSQL($column);
+    }
+}


### PR DESCRIPTION
Implements the prioritized roadmap from the exhaustive multi-agent audit (see `AUDIT.md`), weighted toward the requested goals: **capabilities → performance → optimization**. All changes are additive/backward-compatible unless noted.

## Summary

**Correctness / performance fixes (P0)**
- `reOpen()` now closes the DBAL connection so it actually reconnects after a stale/dropped socket in long-running workers (it previously reused the dead connection).
- DataTables `Builder::withMaxPageLength()` caps unbounded `length=-1` ("All") / oversized requests (resource-exhaustion vector).
- `[OR]` operator now honors `withCaseInsensitive(true)`; `applyOrdering()` bounds-checks the client `order[].column` index.
- The toolbar query middleware/collector is wired only under `CI_DEBUG` (via `shouldInstrumentQueries()` seam), removing per-statement overhead in production.
- `composer.json`: pin `doctrine/dbal ^4`, drop the unused `jms/serializer-bundle`, add `suggest` for `ext-redis`/`ext-memcached`/`doctrine/migrations`.

**New capabilities (config surfaces, re-applied on `reOpen()`)**
- `customTypes`, `sqlFilters`/`enabledFilters`, `eventListeners`/`eventSubscribers`, `dbalMiddlewares`, `defaultRepositoryClass`.
- Production query logging (`queryLogging`/`slowQueryThreshold`/`queryLogLevel`) via `Logging\QueryLoggerMiddleware` (PSR-3) — works in any environment.

**CLI**
- Spark commands `doctrine:cache:clear`, `doctrine:validate`, `doctrine:info`, `doctrine:schema:update` (all accept `--group`).
- `cli-config.php`: `__DIR__`-based autoload + lazy per-group `EntityManagerProvider` so `orm:* --em=<group>` can target any database group.

**Docs**: removed ORM-2-era CLI commands (removed in ORM 3), documented the new extension points/logging/commands, updated CHANGELOG.

## Test Plan
- [x] PHPUnit: 163 tests pass (MySQL + SQLite), 5 env-dependent skips
- [x] Line coverage 91.6% (>= prior 90.5%)
- [x] PHPStan level 6 — no errors
- [x] Psalm — no errors
- [x] Rector (dry-run) — clean
- [x] PHP-CS-Fixer — clean
- [ ] Reviewer: confirm `composer update` resolves cleanly without `jms/serializer-bundle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)