### PR TITLE
docs: add GitHub Pages documentation link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Doctrine ORM 3 integration for CodeIgniter 4.
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/daycry/doctrine)](https://packagist.org/packages/daycry/doctrine)
 [![GitHub stars](https://img.shields.io/github/stars/daycry/doctrine)](https://packagist.org/packages/daycry/doctrine)
 [![GitHub license](https://img.shields.io/github/license/daycry/doctrine)](https://github.com/daycry/doctrine/blob/master/LICENSE)
+[![Documentation](https://img.shields.io/badge/docs-daycry.github.io%2Fdoctrine-blue?logo=materialformkdocs&logoColor=white)](https://daycry.github.io/doctrine/)
+
+📖 **Documentation:** <https://daycry.github.io/doctrine/>
 
 ## Features
 


### PR DESCRIPTION
Adds a prominent **Documentation** badge and a `📖 Documentation:` link to the
README header, pointing to the published MkDocs site at
<https://daycry.github.io/doctrine/>.

## Test Plan
- [x] README renders; both the badge and the link resolve to the live Pages site (HTTP 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)